### PR TITLE
NEB-532: Allow library integration tests to run in primary build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -167,38 +167,6 @@ workflows:
         - is_compress: 'true'
         - zip_name: javadoc
         - deploy_path: "$PROJECT_LOCATION/$LIBRARY_MODULE/build/javadoc"
-
-    # Instrumented tests running agains the access-checkout-android androidTests should be here,
-    # however there is a limitation on bitrise that we cannot run more than one instrumented virtual device test
-    # per workflow. See: https://discuss.bitrise.io/t/android-virtual-device-testing-on-multiple-modules/4241
-    # Once the demo app is split into a seperate project from the library, then we will be able to run these in the
-    # Bitrise pipeline
-
-    - android-build@0.9.5:
-        title: "Build test APK"
-        inputs:
-        - variant: "${APP_VARIANT}AndroidTest"
-        - project_location: "$PROJECT_LOCATION"
-        - module: "$APP_MODULE"
-    - script@1.1.5:
-        title: "Set path to test APK"
-        inputs:
-        - content: |-
-            #!/bin/bash
-            envman add --key "BITRISE_TEST_APK" --value "$BITRISE_APK_PATH"
-    - android-build:
-        title: "Build app APK"
-        inputs:
-        - module: "$APP_MODULE"
-        - variant: "$APP_VARIANT"
-        - project_location: "$PROJECT_LOCATION"
-    - virtual-device-testing-for-android@1.0.5:
-        title: "Run UI tests against app"
-        inputs:
-        - test_type: instrumentation
-        - test_apk_path: "$BITRISE_TEST_APK"
-        - test_devices: |-
-            Pixel2,28,en,portrait
     - deploy-to-bitrise-io@1.3.19:
         inputs:
         - notify_user_groups: none
@@ -248,7 +216,43 @@ workflows:
         inputs:
           - notify_user_groups: testers, developers
     - cache-push@2.0.5: {}
-  overnight-integration:
+
+  primary-ui:
+    steps:
+      - cache-pull@2.0.1: {}
+      - install-missing-android-tools@2.3.4:
+          inputs:
+            - gradlew_path: "$PROJECT_LOCATION/gradlew"
+      - android-build@0.9.5:
+          title: "Build test APK"
+          inputs:
+            - variant: "${APP_VARIANT}AndroidTest"
+            - project_location: "$PROJECT_LOCATION"
+            - module: "$APP_MODULE"
+      - script@1.1.5:
+          title: "Set path to test APK"
+          inputs:
+            - content: |-
+                #!/bin/bash
+                envman add --key "BITRISE_TEST_APK" --value "$BITRISE_APK_PATH"
+      - android-build:
+          title: "Build app APK"
+          inputs:
+            - module: "$APP_MODULE"
+            - variant: "$APP_VARIANT"
+            - project_location: "$PROJECT_LOCATION"
+      - virtual-device-testing-for-android@1.0.5:
+          title: "Run UI tests against app"
+          inputs:
+            - test_type: instrumentation
+            - test_apk_path: "$BITRISE_TEST_APK"
+            - test_devices: |-
+                Pixel2,28,en,portrait
+      - deploy-to-bitrise-io@1.3.19:
+          inputs:
+            - notify_user_groups: testers, developers
+      - cache-push@2.0.5: {}
+  integration:
     steps:
       - cache-pull@2.0.1: {}
       - script@1.1.5:


### PR DESCRIPTION
We are going to make use of Bitrise's capability to run concurrent workflows for
a single build trigger. Therefore the primary workflow will be changed as follows:

* The primary workflow on bitrise will spawn two new agents to run the integration tests
and the UI tests separately
* The UI tests will be removed from the primary build agent
* Once all 3 agents have finished running, the primary agent will aggregate the build
reports from all 3 and report back to github as a single report (if it's a PR build)