### PR TITLE
NEB-338: UI test fix for SDK version 23 or below

### DIFF
--- a/checkout/sample/src/androidTestMock/java/com/worldpay/access/checkout/CardConfigurationLongDelayIntegrationTest.kt
+++ b/checkout/sample/src/androidTestMock/java/com/worldpay/access/checkout/CardConfigurationLongDelayIntegrationTest.kt
@@ -12,6 +12,9 @@ import com.worldpay.access.checkout.UITestUtils.closeKeyboard
 import com.worldpay.access.checkout.UITestUtils.getFailColor
 import com.worldpay.access.checkout.UITestUtils.getSuccessColor
 import com.worldpay.access.checkout.UITestUtils.uiObjectWithId
+import com.worldpay.access.checkout.UITestUtils.updateCVVDetails
+import com.worldpay.access.checkout.UITestUtils.updateMonthDetails
+import com.worldpay.access.checkout.UITestUtils.updatePANDetails
 import com.worldpay.access.checkout.matchers.BrandVectorImageMatcher
 import com.worldpay.access.checkout.model.CardBrand
 import com.worldpay.access.checkout.model.CardConfiguration
@@ -128,16 +131,14 @@ class CardConfigurationLongDelayIntegrationTest {
         assertFalse(submit.isEnabled)
 
         // Re-enter a luhn valid, mastercard identified card and valid date
-        cardText.text = luhnValidMastercardCard
-        monthText.click()
-        monthText.text = month
-        cvvText.click()
+        updatePANDetails(luhnValidMastercardCard)
+        updateMonthDetails(month)
 
         // Attempt to type more than allowed input for CVV
         val validCVV = "123"
-        cvvText.text = validCVV
+        updateCVVDetails(validCVV)
         assertEquals(successColor, cvvEditText.currentTextColor)
-        cvvText.text = "12345"
+        updateCVVDetails("12345")
         assertEquals(validCVV, cvvEditText.text.toString())
 
         // Verify that all the fields are now in a success state and can be submitted


### PR DESCRIPTION
Using UI automator on devices running SDK version 23 or below is causing an issue when
 attempting to set the text to be more than allowed length after a length filter is applied.
 The Android framework was throwing an IndexOutOfBoundsException when trying to apply the
 text change.

 The fix applied here is to use Espresso for attempting to set and verify the text.
 UI automator is no longer needed after the point at which the AsyncTask for fetching the card
  configuration has completed. Therefore Espresso can be used as it's operations won't be blocked
  by the in-progress AsyncTask, which we cannot use before that point for interacting with the UI
  and asserting in-progress state of the app.