### PR TITLE
NEB-533: Updated assembleRelease task to rename artifact to include version

### DIFF
--- a/checkout/access-checkout-android/build.gradle
+++ b/checkout/access-checkout-android/build.gradle
@@ -130,9 +130,15 @@ android {
 
 }
 
-android.libraryVariants.all { variant ->
-    variant.outputs.all {
-        outputFileName = "${archivesBaseName}-${version}.aar"
+afterEvaluate {
+    def filePrefix = "$buildDir/outputs/aar/$archivesBaseName"
+    def fileSuffix = "aar"
+    def originalFile = file("$filePrefix-release.$fileSuffix")
+    def renamedFile = "$filePrefix-$version.$fileSuffix"
+    tasks.named("assembleRelease").configure {
+        doLast {
+            originalFile.renameTo(renamedFile)
+        }
     }
 }
 


### PR DESCRIPTION
It appears the gradle update to 5.1 has caused this issue:
https://github.com/gradle/gradle/issues/8328

Suggestions were applied to rename the file afterEvaluate on the assembleRelease task