### PR TITLE
NEB-543: Added a test for verifying local card config against schema

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,6 +14,18 @@ workflows:
         inputs:
         - gradlew_path: "$PROJECT_LOCATION/gradlew"
     - android-lint@0.9.5:
+        title: "Lint check on app module"
+        inputs:
+          - project_location: "$PROJECT_LOCATION"
+          - module: "$APP_MODULE"
+          - variant: "$APP_PROD_VARIANT"
+    - android-unit-test@0.9.5:
+        title: "Unit tests on app module"
+        inputs:
+          - project_location: "$PROJECT_LOCATION"
+          - module: "$APP_MODULE"
+          - variant: "$APP_PROD_VARIANT"
+    - android-lint@0.9.5:
         title: "Lint check on Library module"
         inputs:
         - project_location: "$PROJECT_LOCATION"
@@ -123,6 +135,18 @@ workflows:
     - install-missing-android-tools@2.3.4:
         inputs:
         - gradlew_path: "$PROJECT_LOCATION/gradlew"
+    - android-lint@0.9.5:
+        title: "Lint check on app module"
+        inputs:
+          - project_location: "$PROJECT_LOCATION"
+          - module: "$APP_MODULE"
+          - variant: "$APP_PROD_VARIANT"
+    - android-unit-test@0.9.5:
+        title: "Unit tests on app module"
+        inputs:
+          - project_location: "$PROJECT_LOCATION"
+          - module: "$APP_MODULE"
+          - variant: "$APP_PROD_VARIANT"
     - android-lint@0.9.5:
         title: "Lint check on Library module"
         inputs:

--- a/checkout/sample/build.gradle
+++ b/checkout/sample/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'com.github.java-json-tools:json-schema-validator:2.2.10'
+
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/checkout/sample/src/test/java/com/worldpay/access/checkout/CardConfigurationSchemaTest.kt
+++ b/checkout/sample/src/test/java/com/worldpay/access/checkout/CardConfigurationSchemaTest.kt
@@ -1,0 +1,25 @@
+package com.worldpay.access.checkout
+
+import com.github.fge.jackson.JsonLoader
+import com.github.fge.jsonschema.main.JsonSchemaFactory
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.URL
+
+class CardConfigurationSchemaTest {
+
+    @Test
+    fun `given local card configuration file in repo then should be valid against remote card configuration JSON schema`() {
+        val url = "https://access.worldpay.com/access-checkout/cardConfigurationSchema.json"
+
+        val schema = JsonLoader.fromURL(URL(url))
+        val cardConfiguration = JsonLoader.fromPath("src/mock/res/raw/card_configuration_file.json")
+
+        val jsonSchemaFactory = JsonSchemaFactory.byDefault()
+        val jsonSchema = jsonSchemaFactory.getJsonSchema(schema)
+
+        val validInstance = jsonSchema.validInstance(cardConfiguration)
+
+        assertTrue(validInstance)
+    }
+}


### PR DESCRIPTION
This will be run as a unit test in the sample app module, where we use
the local card configuration file in the project for stubbing
in the Mockserver class.

Validating against the remote card configuration schema will allow us to
be sure that the card configuration is always correct for the purposes of
running against our UI tests.