### PR TITLE
US459558: escape ':' colon characters in PACT contract matching rules…

### DIFF
--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/PactUtils.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/PactUtils.kt
@@ -1,0 +1,36 @@
+package com.worldpay.access.checkout.api.pact
+
+import au.com.dius.pact.consumer.dsl.DslPart
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleGroup
+
+/**
+ * The behaviour of the Pact JCM consumer Junit library has changed in version 4
+ * Colons are allowed as part of identifiers but not escaped in matching rules
+ * This is due to a change in behaviour following to this requested change:
+ * https://github.com/pact-foundation/pact-jvm/issues/965
+ *
+ * This is required to escape .xxx:yyy into ['xxx:yyy'] so that the matching rules can
+ * be correctly processed during verification on the Provider side
+ */
+class PactUtils {
+    companion object {
+        fun escapeColonsInMatchingRules(dslPart: DslPart): DslPart {
+            val oldMatchingRules: MutableMap<String, MatchingRuleGroup> =
+                dslPart.matchers.matchingRules
+            val newMatchingRules: MutableMap<String, MatchingRuleGroup> = HashMap()
+            oldMatchingRules.forEach {
+                val regex = """[a-zA-Z0-9]+\:[a-zA-Z0-9]+""".toRegex()
+                var newKey = it.key
+                regex.findAll(it.key).forEach {
+                    newKey = newKey.replace(".${it.value}", "['${it.value}']")
+                }
+
+                newMatchingRules[newKey] = it.value
+            }
+
+            dslPart.matchers.matchingRules = newMatchingRules
+
+            return dslPart
+        }
+    }
+}

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/SessionsPactTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/SessionsPactTest.kt
@@ -12,6 +12,7 @@ import com.worldpay.access.checkout.api.discovery.ApiDiscoveryAsyncTaskFactory
 import com.worldpay.access.checkout.api.discovery.ApiDiscoveryClient
 import com.worldpay.access.checkout.api.discovery.DiscoverLinks
 import com.worldpay.access.checkout.api.discovery.DiscoveryCache
+import com.worldpay.access.checkout.api.pact.PactUtils.Companion.escapeColonsInMatchingRules
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.api.exception.ValidationRule
 import com.worldpay.access.checkout.client.testutil.TrustAllSSLSocketFactory
@@ -87,7 +88,7 @@ class SessionsPactTest {
     private val curiesRegex = "https?://[^/]+/rels/sessions/\\{rel\\}.json"
     private val curiesExample = "https://access.worldpay.com/rels/sessions/{rel}.json"
 
-    private val responseBody = PactDslJsonBody()
+    private val responseBody = escapeColonsInMatchingRules(PactDslJsonBody()
         .`object`("_links")
         .`object`("sessions:session")
         .stringMatcher("href", sessionReferenceRegex, sessionReferenceExample)
@@ -99,14 +100,14 @@ class SessionsPactTest {
         .booleanValue("templated", true)
         .closeObject()
         .closeArray()
-        .closeObject()
+        .closeObject())
 
-    private val getResponseBody = PactDslJsonBody()
+    private val getResponseBody = escapeColonsInMatchingRules(PactDslJsonBody()
         .`object`("_links")
         .`object`("sessions:paymentsCvc")
         .stringMatcher("href", sessionEndpointRegex, paymentsCvcSessionEndpoint )
         .closeObject()
-        .closeObject()
+        .closeObject())
 
     @Pact(provider = provider, consumer = consumer)
     @SuppressWarnings("unused")

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/VerifiedTokensPactTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/VerifiedTokensPactTest.kt
@@ -9,6 +9,7 @@ import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
 import com.worldpay.access.checkout.api.HttpsClient
 import com.worldpay.access.checkout.api.discovery.DiscoverLinks
+import com.worldpay.access.checkout.api.pact.PactUtils.Companion.escapeColonsInMatchingRules
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.api.exception.ValidationRule
 import com.worldpay.access.checkout.client.testutil.TrustAllSSLSocketFactory
@@ -87,7 +88,7 @@ class VerifiedTokensPactTest {
     private val curiesRegex = "https?://[^/]+/rels/verifiedTokens/\\{rel\\}.json"
     private val curiesExample = "https://access.worldpay.com/rels/verifiedTokens/{rel}.json"
     
-    private val responseBody = PactDslJsonBody()
+    private val responseBody = escapeColonsInMatchingRules(PactDslJsonBody()
         .`object`("_links")
         .`object`("verifiedTokens:session")
         .stringMatcher("href", sessionReferenceRegex, sessionReferenceExample)
@@ -99,14 +100,14 @@ class VerifiedTokensPactTest {
         .booleanValue("templated", true)
         .closeObject()
         .closeArray()
-        .closeObject()
+        .closeObject())
 
-    private val getResponseBody = PactDslJsonBody()
+    private val getResponseBody = escapeColonsInMatchingRules(PactDslJsonBody()
         .`object`("_links")
         .`object`("verifiedTokens:sessions")
         .stringMatcher("href", discoveryEndpointRegex, verifiedTokensSessionEndpoint)
         .closeObject()
-        .closeObject()
+        .closeObject())
 
     @Pact(provider = provider, consumer = consumer)
     @SuppressWarnings("unused")

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/VerifiedTokensPactTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/pact/VerifiedTokensPactTest.kt
@@ -72,7 +72,7 @@ class VerifiedTokensPactTest {
     private val expiryMonth = 12
     private val integerMonthTooSmall = 0
     private val integerMonthTooLarge = 13
-    private val expiryYear = 2020
+    private val expiryYear = 2030
 
     private val cvc = "123"
     private val cvcNonNumerical = "aaa"


### PR DESCRIPTION
… to fix contract verification