### PR TITLE
US957364: fix for an issue where the AccessCheckoutClientBuilder thro…

### DIFF
--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/session/ActivityLifecycleObserverIntegrationTest.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/session/ActivityLifecycleObserverIntegrationTest.kt
@@ -1,0 +1,55 @@
+package com.worldpay.access.checkout.session
+
+import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.test.platform.app.InstrumentationRegistry
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
+import com.worldpay.access.checkout.client.session.listener.SessionResponseListener
+import com.worldpay.access.checkout.client.session.model.SessionType
+import com.worldpay.access.checkout.session.broadcast.LocalBroadcastManagerFactory
+import com.worldpay.access.checkout.session.broadcast.SessionBroadcastManagerFactory
+import org.junit.Before
+import org.junit.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito
+
+class ActivityLifecycleObserverIntegrationTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    private val tag = "some-tag"
+    private val sessionBroadcastManagerFactory = createSessionBroadcastManagerFactory(context)
+    private val lifecycleOwner: LifecycleOwner = Mockito.mock(LifecycleOwner::class.java)
+    private var lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
+
+    @Before
+    fun setup() {
+        given(lifecycleOwner.lifecycle).willReturn(lifecycleRegistry)
+    }
+
+    @Test
+    fun shouldNotThrowExceptionWhenNotInitialisedOnMainThread() {
+        ActivityLifecycleObserver(tag, lifecycleOwner, sessionBroadcastManagerFactory)
+    }
+
+    @Test
+    fun shouldNotThrowExceptionWhenInitialisedOnMainThread() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ActivityLifecycleObserver(tag, lifecycleOwner, sessionBroadcastManagerFactory)
+        }
+    }
+
+    private fun createSessionBroadcastManagerFactory(context: Context): SessionBroadcastManagerFactory {
+        val localBroadcastManagerFactory = LocalBroadcastManagerFactory(context)
+
+        val sessionResponseListener = object : SessionResponseListener {
+            override fun onSuccess(sessionResponseMap: Map<SessionType, String>) {}
+            override fun onError(error: AccessCheckoutException) {}
+        }
+
+        return SessionBroadcastManagerFactory(
+            localBroadcastManagerFactory,
+            sessionResponseListener
+        )
+    }
+}

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
@@ -1,5 +1,7 @@
 package com.worldpay.access.checkout.session
 
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -30,7 +32,9 @@ internal class ActivityLifecycleObserver(
     }
 
     init {
-        lifecycleOwner.lifecycle.addObserver(this)
+        Handler(Looper.getMainLooper()).post {
+            lifecycleOwner.lifecycle.addObserver(this)
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
@@ -14,7 +14,8 @@ internal class ActivityLifecycleObserver(
     private val tag: String,
     lifecycleOwner: LifecycleOwner,
     sessionBroadcastManagerFactory: SessionBroadcastManagerFactory,
-    private val sessionBroadcastManager: SessionBroadcastManager = sessionBroadcastManagerFactory.createInstance()
+    private val sessionBroadcastManager: SessionBroadcastManager = sessionBroadcastManagerFactory.createInstance(),
+    handler: Handler = Handler(Looper.getMainLooper())
 ) : LifecycleObserver {
 
     companion object {
@@ -32,7 +33,7 @@ internal class ActivityLifecycleObserver(
     }
 
     init {
-        Handler(Looper.getMainLooper()).post {
+        handler.post {
             lifecycleOwner.lifecycle.addObserver(this)
         }
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/ActivityLifecycleObserver.kt
@@ -15,7 +15,7 @@ internal class ActivityLifecycleObserver(
     lifecycleOwner: LifecycleOwner,
     sessionBroadcastManagerFactory: SessionBroadcastManagerFactory,
     private val sessionBroadcastManager: SessionBroadcastManager = sessionBroadcastManagerFactory.createInstance(),
-    handler: Handler = Handler(Looper.getMainLooper())
+    mainLooperHandler: Handler = Handler(Looper.getMainLooper())
 ) : LifecycleObserver {
 
     companion object {
@@ -33,8 +33,12 @@ internal class ActivityLifecycleObserver(
     }
 
     init {
-        handler.post {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
             lifecycleOwner.lifecycle.addObserver(this)
+        } else {
+            mainLooperHandler.post {
+                lifecycleOwner.lifecycle.addObserver(this)
+            }
         }
     }
 

--- a/access-checkout/src/test/java/android/os/Looper.java
+++ b/access-checkout/src/test/java/android/os/Looper.java
@@ -1,0 +1,25 @@
+package android.os;
+
+import static org.mockito.Mockito.mock;
+
+public class Looper {
+    static private Looper myLooper;
+    static private Looper mainLooper;
+
+    public static Looper myLooper() {
+        return myLooper;
+    }
+
+    public static Looper getMainLooper() {
+        return mainLooper;
+    }
+
+    public static void resetAnyLooperToNull() {
+        myLooper = null;
+        mainLooper = null;
+    }
+
+    public static void prepareMainLooper() {
+        myLooper = mock(Looper.class);
+    }
+}

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/ActivityLifecycleObserverTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/ActivityLifecycleObserverTest.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.session
 
+import android.os.Handler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.session.ActivityLifecycleObserver.Companion.inLifeCycleState
@@ -7,8 +8,8 @@ import com.worldpay.access.checkout.session.broadcast.SessionBroadcastManager
 import com.worldpay.access.checkout.session.broadcast.SessionBroadcastManagerFactory
 import org.junit.Before
 import org.junit.Test
-import org.mockito.BDDMockito.given
-import org.mockito.BDDMockito.verify
+import org.mockito.BDDMockito.*
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -26,13 +27,27 @@ class ActivityLifecycleObserverTest {
     @Before
     fun setUp() {
         given(lifecycleOwner.lifecycle).willReturn(lifecycle)
-        activityLifeCycleObserver =
-            ActivityLifecycleObserver(
-                tag,
-                lifecycleOwner,
-                sessionBroadcastManagerFactory,
-                sessionBroadcastManager
-            )
+
+        activityLifeCycleObserver = ActivityLifecycleObserver(
+            tag, lifecycleOwner, sessionBroadcastManagerFactory, sessionBroadcastManager
+        )
+    }
+
+    @Test
+    fun `should add instance as a lifecycle observer by posting on the handler`() {
+        val handler = mock(Handler::class.java)
+        `when`(handler.post(any())).then { invocation ->
+            invocation.getArgument<Runnable>(0).run()
+            true
+        }
+
+        activityLifeCycleObserver = ActivityLifecycleObserver(
+            tag, lifecycleOwner, sessionBroadcastManagerFactory, sessionBroadcastManager,
+            handler
+        )
+
+        verify(lifecycle).addObserver(activityLifeCycleObserver)
+        verify(handler).post(any())
     }
 
     @Test


### PR DESCRIPTION
…ws an exception when its build() method is not called on the main UI thread

- this issue is due to a change in the "androix.lifecycle:lifecycle-*:" libraries starting from version 2.3.0 where the LifecycleRegistry enforces the call to addObserver() to be made on the main UI thread

More information available here - https://developer.android.com/jetpack/androidx/releases/lifecycle#version_230_3