### PR TITLE
US1376883: add support to override SDK version passed to session services  This feature supports only passing access-checkout-react-native/x.y.z or access-checkout-android/.a.b.c with a.b.c being the current Android native SDK version

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/CardSessionClient.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/CardSessionClient.kt
@@ -1,6 +1,5 @@
 package com.worldpay.access.checkout.session.api.client
 
-import com.worldpay.access.checkout.BuildConfig
 import com.worldpay.access.checkout.api.HttpsClient
 import com.worldpay.access.checkout.api.serialization.Deserializer
 import com.worldpay.access.checkout.api.serialization.Serializer
@@ -25,7 +24,7 @@ internal class CardSessionClient(
         val headers = HashMap<String, String>()
         headers[CONTENT_TYPE_HEADER] = VERIFIED_TOKENS_MEDIA_TYPE
         headers[ACCEPT_HEADER] = VERIFIED_TOKENS_MEDIA_TYPE
-        headers[WP_SDK_PRODUCT_HEADER] = PRODUCT_NAME + BuildConfig.VERSION_NAME
+        headers[WpSdkHeader.name] = WpSdkHeader.value
 
         return httpsClient.doPost(url, request, headers, serializer, deserializer)
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/CvcSessionClient.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/CvcSessionClient.kt
@@ -1,6 +1,5 @@
 package com.worldpay.access.checkout.session.api.client
 
-import com.worldpay.access.checkout.BuildConfig
 import com.worldpay.access.checkout.api.HttpsClient
 import com.worldpay.access.checkout.api.serialization.Deserializer
 import com.worldpay.access.checkout.api.serialization.Serializer
@@ -25,7 +24,7 @@ internal class CvcSessionClient(
         val headers = HashMap<String, String>()
         headers[CONTENT_TYPE_HEADER] = SESSIONS_MEDIA_TYPE
         headers[ACCEPT_HEADER] = SESSIONS_MEDIA_TYPE
-        headers[WP_SDK_PRODUCT_HEADER] = PRODUCT_NAME + BuildConfig.VERSION_NAME
+        headers[WpSdkHeader.name] = WpSdkHeader.value
 
         return httpsClient.doPost(url, request, headers, serializer, deserializer)
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
@@ -1,0 +1,37 @@
+package com.worldpay.access.checkout.session.api.client
+
+import com.worldpay.access.checkout.BuildConfig
+import java.lang.RuntimeException
+
+class WpSdkHeader {
+    companion object {
+        private const val INVALID_VERSION_ERROR_MESSAGE =
+            "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
+
+        private const val PRODUCT_NAME = "access-checkout-android/"
+        internal const val DEFAULT_VALUE = PRODUCT_NAME + BuildConfig.VERSION_NAME
+
+        internal const val name = "X-WP-SDK"
+
+        private var valueField = DEFAULT_VALUE
+        internal val value get() = valueField
+
+        fun overrideValue(newValue: String) {
+            if (!validateVersionForOverride(newValue)) {
+                throw RuntimeException(INVALID_VERSION_ERROR_MESSAGE)
+            }
+
+            valueField = newValue
+        }
+
+        private fun validateVersionForOverride(untrustedVersion: String): Boolean {
+            if (untrustedVersion.equals(DEFAULT_VALUE)) {
+                return true
+            }
+
+            val pattern =
+                "access\\-checkout\\-react\\-native\\/[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}"
+            return pattern.toRegex().matches(untrustedVersion)
+        }
+    }
+}

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
@@ -6,7 +6,7 @@ import java.lang.RuntimeException
 class WpSdkHeader private constructor() {
     companion object {
         private const val INVALID_VERSION_ERROR_MESSAGE =
-            "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
+            "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-android version."
 
         private const val PRODUCT_NAME = "access-checkout-android/"
         internal const val DEFAULT_VALUE = PRODUCT_NAME + BuildConfig.VERSION_NAME

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/WpSdkHeader.kt
@@ -3,7 +3,7 @@ package com.worldpay.access.checkout.session.api.client
 import com.worldpay.access.checkout.BuildConfig
 import java.lang.RuntimeException
 
-class WpSdkHeader {
+class WpSdkHeader private constructor() {
     companion object {
         private const val INVALID_VERSION_ERROR_MESSAGE =
             "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/WpSdkHeaderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/WpSdkHeaderTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 
 internal class WpSdkHeaderTest {
     private val expectedErrorMessage =
-        "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
+        "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-android version."
 
     @AfterTest
     fun tearDown() {
@@ -62,7 +62,7 @@ internal class WpSdkHeaderTest {
     }
 
     @Test
-    fun testAllowsToOverrideVersionWithDefaultAccessCheckoutIosVersion() {
+    fun testAllowsToOverrideVersionWithDefaultAccessCheckoutAndroidVersion() {
         val newVersion = "access-checkout-android/" + BuildConfig.VERSION_NAME
 
         WpSdkHeader.overrideValue(newVersion)
@@ -71,7 +71,7 @@ internal class WpSdkHeaderTest {
     }
 
     @Test
-    fun testThrowsErrorWhenAttemptingToOverrideWithAccessCheckoutIosOfDifferentSemanticVersion() {
+    fun testThrowsErrorWhenAttemptingToOverrideWithAccessCheckoutAndroidIfDifferentSemanticVersion() {
         val newVersion = "access-checkout-android/1.2.3"
 
         assertFailsWith<RuntimeException>(

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/WpSdkHeaderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/WpSdkHeaderTest.kt
@@ -1,0 +1,85 @@
+package com.worldpay.access.checkout.session.api.client
+
+import com.worldpay.access.checkout.BuildConfig
+import org.junit.Test
+import java.lang.RuntimeException
+import kotlin.test.AfterTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class WpSdkHeaderTest {
+    private val expectedErrorMessage =
+        "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
+
+    @AfterTest
+    fun tearDown() {
+        WpSdkHeader.overrideValue(WpSdkHeader.DEFAULT_VALUE)
+    }
+
+    @Test
+    fun testAllowsToOverrideVersionWithAccessCheckoutReactNativeVersion() {
+        val newVersion = "access-checkout-react-native/10.3.15"
+
+        WpSdkHeader.overrideValue(newVersion)
+
+        assertEquals(newVersion, WpSdkHeader.value)
+    }
+
+    @Test
+    fun testThrowsErrorWhenSemanticVersionIsNotInXYZFormat() {
+        val newVersion = "access-checkout-react-native/10.3"
+
+        assertFailsWith<RuntimeException>(
+            message = expectedErrorMessage,
+            block = {
+                WpSdkHeader.overrideValue(newVersion)
+            }
+        )
+    }
+
+    @Test
+    fun testThrowsErrorWhenAccessCheckoutReactNativeDoesNotHaveCorrectCase() {
+        val newVersion = "Access-Checkout-REACT-native/10.3.15"
+
+        assertFailsWith<RuntimeException>(
+            message = expectedErrorMessage,
+            block = {
+                WpSdkHeader.overrideValue(newVersion)
+            }
+        )
+    }
+
+    @Test
+    fun testThrowsErrorWhenAttemptingToOverrideWithNonAccessCheckoutReactNativeVersion() {
+        val newVersion = "something-else/10.3.15"
+
+        assertFailsWith<RuntimeException>(
+            message = expectedErrorMessage,
+            block = {
+                WpSdkHeader.overrideValue(newVersion)
+            }
+        )
+    }
+
+    @Test
+    fun testAllowsToOverrideVersionWithDefaultAccessCheckoutIosVersion() {
+        val newVersion = "access-checkout-android/" + BuildConfig.VERSION_NAME
+
+        WpSdkHeader.overrideValue(newVersion)
+
+        assertEquals(newVersion, WpSdkHeader.value)
+    }
+
+    @Test
+    fun testThrowsErrorWhenAttemptingToOverrideWithAccessCheckoutIosOfDifferentSemanticVersion() {
+        val newVersion = "access-checkout-android/1.2.3"
+
+        assertFailsWith<RuntimeException>(
+            message = expectedErrorMessage,
+            block = {
+                WpSdkHeader.overrideValue(newVersion)
+            }
+        )
+    }
+}
+


### PR DESCRIPTION
## What
This PR is to add a feature for use by Worldpay and designed to allow overriding the version header that the SDK sends to Worldpay services when requesting a session.
The functionality supports only passing an access-checkout-react-native version or the current access-checkout-android version (the latter being used in tests only)

## How
A new method has been added to allow overriding the header containing the version which is sent when requesting sessions

## Why
This feature is to allow Worldpay to capture the correct Access Checkout React Native SDK version when it generates sessions.