### PR TITLE
US1390524: change build pipeline to run tests against API levels 32 and 33

### DIFF
--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -1,5 +1,5 @@
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     packagingOptions {
         exclude "**/attach_hotspot_windows.dll"

--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/access-checkout/src/test/resources/com/worldpay/access/checkout/robolectric.properties
+++ b/access-checkout/src/test/resources/com/worldpay/access/checkout/robolectric.properties
@@ -1,1 +1,1 @@
-maxSdk = 30
+maxSdk = 33

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -254,7 +254,7 @@ workflows:
                 Pixel2,27,en,portrait
                 Pixel2,28,en,portrait
                 Pixel2,29,en,portrait
-                Pixel2,30,en,portrait
+                Pixel2.arm,30,en,portrait
                 Pixel2.arm,32,en,portrait
                 Pixel2.arm,33,en,portrait
       - cache-push@2.7.1: { }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -255,6 +255,8 @@ workflows:
                 Pixel2,28,en,portrait
                 Pixel2,29,en,portrait
                 Pixel2,30,en,portrait
+                Pixel2.arm,32,en,portrait
+                Pixel2.arm,33,en,portrait
       - cache-push@2.7.1: { }
 
 app:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -204,48 +204,18 @@ workflows:
           - webhook_url: "$SLACK_ACO_BUILD_WEBHOOK_URL"
 
   primary-ui-mock:
-    steps:
-      - set-java-version@1: {"11"}
-      - cache-pull@2.7.2: {}
-      - install-missing-android-tools@3.1.0:
-          inputs:
-            - gradlew_path: "gradlew"
-      - android-build@1.0.5:
-          title: "Build test APK"
-          inputs:
-            - variant: "${APP_MOCK_VARIANT}AndroidTest"
-            - module: "$APP_MODULE"
-      - script@1.2.0:
-          title: "Set path to test APK"
-          inputs:
-            - content: |-
-                #!/bin/bash
-                envman add --key "BITRISE_TEST_MOCK_APK" --value "$BITRISE_APK_PATH"
-      - android-build@1.0.5:
-          title: "Build app APK"
-          inputs:
-            - module: "$APP_MODULE"
-            - variant: "$APP_MOCK_VARIANT"
-      - virtual-device-testing-for-android@1.1.8:
-          title: "Run UI tests against app"
-          inputs:
-            - test_type: instrumentation
-            - test_apk_path: "$BITRISE_TEST_MOCK_APK"
-            - test_timeout: 1200
-            - test_devices: |-
-                Nexus6,21,en,portrait
-                Nexus5,22,en,portrait
-                Nexus5,23,en,portrait
-                Nexus6,24,en,portrait
-                Nexus6,25,en,portrait
-                Pixel2,26,en,portrait
-                Pixel2,27,en,portrait
-                Pixel2,28,en,portrait
-                Pixel2,29,en,portrait
-                Pixel2,30,en,portrait
-      - cache-push@2.7.1: {}
+    envs:
+      - APP_VARIANT: "$APP_MOCK_VARIANT"
+    after_run:
+      - ui-tests
 
   primary-ui-prod:
+    envs:
+      - APP_VARIANT: "$APP_PROD_VARIANT"
+    after_run:
+      - ui-tests
+
+  ui-tests:
     steps:
       - set-java-version@1: { "11" }
       - cache-pull@2.7.2: { }
@@ -255,24 +225,24 @@ workflows:
       - android-build@1.0.5:
           title: "Build test APK"
           inputs:
-            - variant: "${APP_PROD_VARIANT}AndroidTest"
+            - variant: "${APP_VARIANT}AndroidTest"
             - module: "$APP_MODULE"
       - script@1.2.0:
           title: "Set path to test APK"
           inputs:
             - content: |-
                 #!/bin/bash
-                envman add --key "BITRISE_TEST_PROD_APK" --value "$BITRISE_APK_PATH"
+                envman add --key "BITRISE_TEST_APK" --value "$BITRISE_APK_PATH"
       - android-build@1.0.5:
           title: "Build app APK"
           inputs:
             - module: "$APP_MODULE"
-            - variant: "$APP_PROD_VARIANT"
+            - variant: "$APP_VARIANT"
       - virtual-device-testing-for-android@1.1.8:
           title: "Run UI tests against app"
           inputs:
             - test_type: instrumentation
-            - test_apk_path: "$BITRISE_TEST_PROD_APK"
+            - test_apk_path: "$BITRISE_TEST_APK"
             - test_timeout: 1200
             - test_devices: |-
                 Nexus6,21,en,portrait
@@ -286,6 +256,7 @@ workflows:
                 Pixel2,29,en,portrait
                 Pixel2,30,en,portrait
       - cache-push@2.7.1: { }
+
 app:
   envs:
   - LIBRARY_MODULE: access-checkout

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -243,7 +243,7 @@ workflows:
           inputs:
             - test_type: instrumentation
             - test_apk_path: "$BITRISE_TEST_APK"
-            - test_timeout: 1200
+            - test_timeout: 1500
             - test_devices: |-
                 Nexus6,21,en,portrait
                 Nexus5,22,en,portrait

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     testImplementation 'com.github.java-json-tools:json-schema-validator:2.2.10'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         applicationId "com.worldpay.access.checkout.sample"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -191,7 +191,7 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
     }
 
     fun hasBrand(cardBrand: CardBrand): CardFragmentTestUtils {
-        wait { assertEquals(cardBrand.cardBrandName, brandLogo().getTag(R.integer.card_tag)) }
+        wait(maxWaitTimeInMillis = 5000) { assertEquals(cardBrand.cardBrandName, brandLogo().getTag(R.integer.card_tag)) }
         return this
     }
 }

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/matchers/DrawableMatcher.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/matchers/DrawableMatcher.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 
+
 class DrawableMatcher(private val resourceId: Int) : TypeSafeMatcher<View>() {
 
     override fun describeTo(description: Description?) {
@@ -51,8 +52,8 @@ class DrawableMatcher(private val resourceId: Int) : TypeSafeMatcher<View>() {
 
             actualDrawable.bounds = bounds
 
-            val bitmap1 = drawDrawableToBitmap(expectedDrawable)
-            val bitmap2 = drawDrawableToBitmap(actualDrawable)
+            val bitmap1 = toBitmap(expectedDrawable)
+            val bitmap2 = toBitmap(actualDrawable)
 
             if (bitmap1.sameAs(bitmap2)) {
                 return true
@@ -60,6 +61,17 @@ class DrawableMatcher(private val resourceId: Int) : TypeSafeMatcher<View>() {
         }
 
         return false
+    }
+
+    private fun toBitmap(drawable: Drawable): Bitmap {
+        val bitmap = Bitmap.createBitmap(
+            drawable.intrinsicWidth,
+            drawable.intrinsicHeight, Bitmap.Config.ARGB_8888
+        )
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        return bitmap
     }
 
     private fun drawDrawableToBitmap(drawable: Drawable): Bitmap {

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -18,14 +18,14 @@
             android:name="org.apache.http.legacy"
             android:required="false" />
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".MainActivityJavaExample">
+        <activity android:name=".MainActivityJavaExample" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>


### PR DESCRIPTION
# What
Change build pipeline to run tests against API levels 32 and 33

# Why
This is to ensure we have non-regression testing in place for these versions and make sure the SDK remains compatible with the latest versions of Android