### PR TITLE
US1429941: remove functionality which adds hints/placeholders to the card number, expiry date and CVC fields.

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/CvcFieldDecorator.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/CvcFieldDecorator.kt
@@ -29,8 +29,6 @@ internal class CvcFieldDecorator(
         cvcEditText.onFocusChangeListener = cvcFocusChangeListener
 
         applyFilter(cvcEditText, cvcLengthFilter)
-
-        cvcEditText.setHint(R.string.card_cvc_hint)
     }
 
     private fun addTextWatcher() {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/ExpiryDateFieldDecorator.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/ExpiryDateFieldDecorator.kt
@@ -29,8 +29,6 @@ internal class ExpiryDateFieldDecorator(
         expiryDateEditText.onFocusChangeListener = expiryDateFocusChangeListener
 
         applyFilter(expiryDateEditText, expiryDateLengthFilter)
-
-        expiryDateEditText.setHint(R.string.card_expiry_date_hint)
     }
 
     private fun addTextWatcher() {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/PanFieldDecorator.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/PanFieldDecorator.kt
@@ -29,8 +29,6 @@ internal class PanFieldDecorator(
         panEditText.onFocusChangeListener = panFocusChangeListener
 
         applyFilter(panEditText, panNumericFilter)
-
-        panEditText.setHint(R.string.card_number_hint)
     }
 
     private fun addTextWatcher() {

--- a/access-checkout/src/main/res/values/strings.xml
+++ b/access-checkout/src/main/res/values/strings.xml
@@ -1,5 +1,1 @@
-<resources>
-    <string name="card_number_hint">Card Number</string>
-    <string name="card_expiry_date_hint">MM/YY</string>
-    <string name="card_cvc_hint">CVC</string>
-</resources>
+<resources />

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/CvcFieldDecoratorTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/CvcFieldDecoratorTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
-import com.worldpay.access.checkout.R
 import com.worldpay.access.checkout.validation.filters.AccessCheckoutInputFilterFactory
 import com.worldpay.access.checkout.validation.filters.CvcLengthFilter
 import com.worldpay.access.checkout.validation.listeners.focus.CvcFocusChangeListener
@@ -22,6 +21,8 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class CvcFieldDecoratorTest {
@@ -65,12 +66,13 @@ class CvcFieldDecoratorTest {
     }
 
     @Test
-    fun `should add hint to cvc field`() {
+    fun `should not add hint to cvc field`() {
         given(cvcEditText.filters).willReturn(emptyArray())
 
         cvcFieldDecorator.decorate()
 
-        verify(cvcEditText).setHint(R.string.card_cvc_hint)
+        verify(cvcEditText, never()).setHint(anyInt())
+        verify(cvcEditText, never()).setHint(anyString())
     }
 
     @Test

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/ExpiryDateFieldDecoratorTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/ExpiryDateFieldDecoratorTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
-import com.worldpay.access.checkout.R
 import com.worldpay.access.checkout.validation.filters.AccessCheckoutInputFilterFactory
 import com.worldpay.access.checkout.validation.filters.ExpiryDateLengthFilter
 import com.worldpay.access.checkout.validation.listeners.focus.ExpiryDateFocusChangeListener
@@ -22,6 +21,8 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class ExpiryDateFieldDecoratorTest {
@@ -64,12 +65,13 @@ class ExpiryDateFieldDecoratorTest {
     }
 
     @Test
-    fun `should add hint to expiry date field`() {
+    fun `should not add hint to expiry date field`() {
         given(expiryDateEditText.filters).willReturn(emptyArray())
 
         expiryDateFieldDecorator.decorate()
 
-        verify(expiryDateEditText).setHint(R.string.card_expiry_date_hint)
+        verify(expiryDateEditText, never()).setHint(anyInt())
+        verify(expiryDateEditText, never()).setHint(anyString())
     }
 
     @Test

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/PanFieldDecoratorTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/validation/decorators/PanFieldDecoratorTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
-import com.worldpay.access.checkout.R
 import com.worldpay.access.checkout.testutils.CardNumberUtil.visaPan
 import com.worldpay.access.checkout.validation.filters.AccessCheckoutInputFilterFactory
 import com.worldpay.access.checkout.validation.filters.PanNumericFilter
@@ -23,6 +22,8 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class PanFieldDecoratorTest {
@@ -63,12 +64,13 @@ class PanFieldDecoratorTest {
     }
 
     @Test
-    fun `should add hint to pan field`() {
+    fun `should not add hint to pan field`() {
         given(panEditText.filters).willReturn(emptyArray())
 
         panFieldDecorator.decorate()
 
-        verify(panEditText).setHint(R.string.card_number_hint)
+        verify(panEditText, never()).setHint(anyInt())
+        verify(panEditText, never()).setHint(anyString())
     }
 
     @Test

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -19,6 +19,7 @@
         android:inputType="number"
         android:maxLines="1"
         android:textColor="@color/DEFAULT"
+        android:hint="@string/card_number_hint"
         app:layout_constraintEnd_toStartOf="@+id/card_flow_brand_logo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -47,6 +48,7 @@
         android:imeOptions="actionDone|flagNoFullscreen"
         android:inputType="number"
         android:textColor="@color/DEFAULT"
+        android:hint="@string/card_expiry_date_hint"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/card_flow_text_pan"
         tools:ignore="TextFields" />
@@ -61,6 +63,7 @@
         android:imeOptions="actionDone|flagNoFullscreen"
         android:inputType="number"
         android:textColor="@color/DEFAULT"
+        android:hint="@string/card_cvc_hint"
         app:layout_constraintStart_toEndOf="@+id/card_flow_expiry_date"
         app:layout_constraintTop_toBottomOf="@+id/card_flow_text_pan" />
 

--- a/demo-app/src/main/res/layout/fragment_cvc_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_cvc_flow.xml
@@ -18,6 +18,7 @@
         android:imeOptions="actionDone|flagNoFullscreen"
         android:inputType="number"
         android:textColor="@color/DEFAULT"
+        android:hint="@string/card_cvc_hint"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/demo-app/src/main/res/layout/fragment_restricted_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_restricted_card_flow.xml
@@ -19,6 +19,7 @@
         android:inputType="number"
         android:maxLines="1"
         android:textColor="@color/DEFAULT"
+        android:hint="@string/card_number_hint"
         app:layout_constraintEnd_toStartOf="@+id/restricted_card_flow_brand_logo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -49,6 +50,7 @@
         android:textColor="@color/DEFAULT"
         android:visibility="gone"
         android:enabled="false"
+        android:hint="@string/card_expiry_date_hint"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/restricted_card_flow_text_pan"
         tools:ignore="TextFields" />
@@ -66,6 +68,7 @@
         android:textColor="@color/DEFAULT"
         android:visibility="gone"
         android:enabled="false"
+        android:hint="@string/card_cvc_hint"
         app:layout_constraintStart_toEndOf="@+id/restricted_card_flow_expiry_date"
         app:layout_constraintTop_toBottomOf="@+id/restricted_card_flow_text_pan" />
 

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -15,5 +15,9 @@
 
     <string name="supported_card_brands_text">Supported Card Brands: Visa, Mastercard &amp; Amex</string>
 
+    <string name="card_number_hint">Card Number</string>
+    <string name="card_expiry_date_hint">MM/YY</string>
+    <string name="card_cvc_hint">CVC</string>
+
     <integer name="card_tag">7348</integer>
 </resources>


### PR DESCRIPTION
## What
This PR is to remove a functionality of the SDK which consists in adding hints/placeholders to the card number, expiry date and CVC fields provided by the merchant.

## Why 
It should not be the responsibility of the SDK to set placeholders on the merchants' fields, it should be the merchants' responsibility. Leaving this responsibility to the SDK could be detrimental to the merchant in a case for instance where the merchant uses a locale other than English in their app.