### PR TITLE
US1708159: add 'Internal' modifier to properties in CardDetails class

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/model/CardDetails.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/model/CardDetails.kt
@@ -11,13 +11,13 @@ import com.worldpay.access.checkout.ui.AccessEditText
  * @property [cvc] an optional [String] containing the cvc
  */
 class CardDetails private constructor(
-    val pan: String?,
-    val expiryDate: ExpiryDate?,
-    val cvc: String?
+    internal val pan: String?,
+    internal val expiryDate: ExpiryDate?,
+    internal val cvc: String?
 ) {
 
     /**
-     * This build helps building the [CardDetails] instance
+     * This builder helps build the [CardDetails] instance
      */
     data class Builder(
         private var pan: String? = null,
@@ -62,8 +62,8 @@ class CardDetails private constructor(
      */
     class ExpiryDate internal constructor(expiryDateAccessEditText: AccessEditText) {
 
-        val month: Int
-        val year: Int
+        internal val month: Int
+        internal val year: Int
 
         private val maxExpiryDateLength = 4
 


### PR DESCRIPTION
## What

- Fix the vulnerability in the CardDetails class

## How
- By adding 'Internal' to the pan, expiry date, cvc, month and year properties in the CardDetails class

## Why
- To prevent the merchant from gaining access to these sensitive information and to be PCI compliant 