### PR TITLE
Us1721015 UI tests fix

### DIFF
--- a/access-checkout/gradle/upload.gradle
+++ b/access-checkout/gradle/upload.gradle
@@ -47,18 +47,18 @@ afterEvaluate {
                     packaging = 'aar'
 
                     description = 'Android SDK library for Worldpay Access Checkout.'
-                    url = 'https://github.com/Worldpay/access-checkout'
+                    url = 'https://github.com/Worldpay/access-checkout-android'
 
                     scm {
-                        connection = 'scm:git:git://github.com/Worldpay/access-checkout.git'
-                        developerConnection = 'scm:git:ssh://github.com/Worldpay/access-checkout.git'
-                        url = 'https://github.com/Worldpay/access-checkout/tree/master'
+                        connection = 'scm:git:git://github.com/Worldpay/access-checkout-android.git'
+                        developerConnection = 'scm:git:ssh://github.com/Worldpay/access-checkout-android.git'
+                        url = 'https://github.com/Worldpay/access-checkout-android/tree/master'
                     }
 
                     licenses {
                         license {
                             name = 'MIT License'
-                            url = 'https://raw.githubusercontent.com/Worldpay/access-checkout/master/LICENSE'
+                            url = 'https://raw.githubusercontent.com/Worldpay/access-checkout-android/master/LICENSE'
                         }
                     }
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/AbstractFieldDecorator.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/decorators/AbstractFieldDecorator.kt
@@ -10,12 +10,9 @@ internal abstract class AbstractFieldDecorator {
         editText: EditText,
         accessCheckoutInputFilter: AccessCheckoutInputFilter
     ) {
-        val filters = mutableListOf<InputFilter>()
-        for (filter in editText.filters) {
-            if (filter !is AccessCheckoutInputFilter && filter !is InputFilter.LengthFilter) {
-                filters.add(filter)
-            }
-        }
+        val filters = editText.filters
+            .filter { it !is AccessCheckoutInputFilter && it !is InputFilter.LengthFilter }
+            .toMutableList()
 
         filters.add(accessCheckoutInputFilter)
         editText.filters = filters.toTypedArray()

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -245,7 +245,6 @@ workflows:
             - test_apk_path: "$BITRISE_TEST_APK"
             - test_timeout: 1500
             - test_devices: |-
-                Nexus6,21,en,portrait
                 Nexus5,22,en,portrait
                 Nexus5,23,en,portrait
                 Nexus6,24,en,portrait

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -191,7 +191,7 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
     }
 
     fun hasBrand(cardBrand: CardBrand): CardFragmentTestUtils {
-        wait(maxWaitTimeInMillis = 5000) { assertEquals(cardBrand.cardBrandName, brandLogo().getTag(R.integer.card_tag)) }
+        wait(maxWaitTimeInMillis = 20000) { assertEquals(cardBrand.cardBrandName, brandLogo().getTag(R.integer.card_tag)) }
         return this
     }
 }


### PR DESCRIPTION
## What
- drop support for Android API level 21 (Android 5.0,5.0.2)
- increase timeout of certain UI tests to cope with the slowness of the build system
- fixed incorrect repo URLs in the Maven publish plugin

## Why
- Android API level 21 is very old, officially unsupported and causing too many issues in our build system so there is no point supporting it anymore
- repo URLs have been fixed so that the information displayed in Maven is correct