### PR TITLE
US1762429: fix memory leak in AccessCheckoutEditText and text watcher

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessEditText.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.InputFilter
+import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
 import android.view.KeyEvent
@@ -130,7 +131,9 @@ class AccessEditText internal constructor(
     /**
      * Methods
      */
-    fun clear() = editText.text.clear()
+    fun clear() {
+        editText.text = SpannableStringBuilder("", 0, 0)
+    }
 
     fun setEms(ems: Int) = editText.setEms(ems)
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/ExpiryDateTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/ExpiryDateTextWatcher.kt
@@ -31,6 +31,7 @@ internal class ExpiryDateTextWatcher(
                 val newExpiryDate = expiryDateSanitiser.sanitise(expiryDate)
                 if (expiryDate != newExpiryDate) {
                     updateText(newExpiryDate)
+                    clearTextBefore()
                     return
                 }
             }
@@ -38,6 +39,7 @@ internal class ExpiryDateTextWatcher(
 
         val result = dateValidator.validate(expiryDate)
         expiryDateValidationResultHandler.handleResult(isValid = result)
+        clearTextBefore()
     }
 
     private fun attemptingToDeleteSeparator(textBefore: String, textAfter: String): Boolean {
@@ -50,5 +52,12 @@ internal class ExpiryDateTextWatcher(
     private fun updateText(text: String) {
         expiryDateEditText.setText(text)
         expiryDateEditText.setSelection(text.length)
+    }
+
+    /**
+     * Designed to clear from memory the text held in the textBefore property
+     */
+    private fun clearTextBefore() {
+        this.textBefore = ""
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -82,6 +82,7 @@ internal class PanTextWatcher(
         val cardValidationRule = getPanValidationRule(brand)
 
         if (trimToMaxLength(cardValidationRule, newPan)) {
+            clearPanBefore()
             return
         }
 
@@ -98,6 +99,12 @@ internal class PanTextWatcher(
         if (panEditText.selectionEnd != expectedCursorPosition && panEditText.length() >= expectedCursorPosition) {
             panEditText.setSelection(expectedCursorPosition)
         }
+
+        clearPanBefore()
+    }
+
+    private fun clearPanBefore() {
+        this.panBefore = ""
     }
 
     /**

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -103,6 +103,9 @@ internal class PanTextWatcher(
         clearPanBefore()
     }
 
+    /**
+     * Designed to clear from memory the text held in the panBefore property
+     */
     private fun clearPanBefore() {
         this.panBefore = ""
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessEditTextTest.kt
@@ -7,12 +7,14 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
+import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -297,11 +299,12 @@ class AccessEditTextTest {
 
     @Test
     fun `clear() should clear EditText text`() {
-        val editableMock = mock<Editable>()
-        given(editTextMock.text).willReturn(editableMock)
+        val argumentCaptor = ArgumentCaptor.forClass(SpannableStringBuilder::class.java)
 
         accessEditText.clear()
-        verify(editableMock).clear()
+
+        verify(accessEditText.editText).text = argumentCaptor.capture()
+        assertEquals(0, argumentCaptor.value.length)
     }
 
     @Test


### PR DESCRIPTION
## What
- fix memory leak in AccessCheckoutEditText where some text entered by the user remains in memory during typing and after clearing text