### PR TITLE
Us1770743 fix various memory leaks

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/HttpsClient.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/HttpsClient.kt
@@ -151,23 +151,19 @@ internal class HttpsClient(
         var clientException: AccessCheckoutException? = null
         var errorData: String? = null
 
-        if (conn.errorStream != null) {
-            conn.errorStream.use { errorStream ->
-                errorData = getResponseData(errorStream)
-                clientException = clientErrorDeserializer.deserialize(errorData!!)
-            }
+        conn.errorStream?.use { errorStream ->
+            errorData = getResponseData(errorStream)
+            clientException = clientErrorDeserializer.deserialize(errorData!!)
         }
 
         return clientException ?: AccessCheckoutException(getMessage(conn, errorData))
     }
 
     private fun getServerError(conn: HttpsURLConnection): AccessCheckoutException {
-        if (conn.errorStream != null) {
-            conn.errorStream.use { errorStream ->
-                val errorData = getResponseData(errorStream)
-                val message = getMessage(conn, errorData)
-                return AccessCheckoutException(message)
-            }
+        conn.errorStream?.use { errorStream ->
+            val errorData = getResponseData(errorStream)
+            val message = getMessage(conn, errorData)
+            return AccessCheckoutException(message)
         }
         return AccessCheckoutException("A server error occurred when trying to make the request")
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -17,7 +17,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.StyleRes
 import androidx.core.widget.TextViewCompat
 import com.worldpay.access.checkout.R
-import java.util.*
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
 
 class AccessCheckoutEditText internal constructor(
     context: Context,
@@ -26,7 +27,7 @@ class AccessCheckoutEditText internal constructor(
     internal val editText: EditText,
 ) : LinearLayout(context, attrs, defStyle) {
     internal companion object {
-        private val allEditTextIds = HashMap<Int, Int?>()
+        private val allEditTextIds = ConcurrentHashMap<Int, Int?>()
 
         fun editTextIdOf(accessCheckoutEditTextId: Int): Int {
             val newId = View.generateViewId()

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.InputFilter
+import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
 import android.view.KeyEvent
@@ -135,7 +136,9 @@ class AccessCheckoutEditText internal constructor(
     /**
      * Methods
      */
-    fun clear() = editText.text.clear()
+    fun clear() {
+        editText.text = SpannableStringBuilder("", 0, 0)
+    }
 
     fun setEms(ems: Int) = editText.setEms(ems)
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -194,7 +194,7 @@ class AccessCheckoutEditText internal constructor(
     public override fun onRestoreInstanceState(state: Parcelable) {
         val bundledState = (state as Bundle)
 
-        super.onRestoreInstanceState(bundledState.getBundle("superState"))
-        editText.onRestoreInstanceState(bundledState.getBundle("editTextState"))
+        super.onRestoreInstanceState(bundledState.getParcelable("superState"))
+        editText.onRestoreInstanceState(bundledState.getParcelable("editTextState"))
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -10,13 +10,14 @@ import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
 import androidx.annotation.StyleRes
 import androidx.core.widget.TextViewCompat
 import com.worldpay.access.checkout.R
-import kotlin.random.Random
+import java.util.*
 
 class AccessCheckoutEditText internal constructor(
     context: Context,
@@ -25,15 +26,22 @@ class AccessCheckoutEditText internal constructor(
     internal val editText: EditText,
 ) : LinearLayout(context, attrs, defStyle) {
     internal companion object {
-        internal val editTextPartialId = Random.nextInt(1000)
+        private val allEditTextIds = HashMap<Int, Int?>()
+
+        fun editTextIdOf(accessCheckoutEditTextId: Int): Int {
+            val newId = View.generateViewId()
+            val editTextId = allEditTextIds.putIfAbsent(accessCheckoutEditTextId, newId)
+            return Optional.ofNullable(editTextId).orElse(newId)
+        }
     }
 
     init {
         orientation = VERTICAL
-        this.editText.id = this.id + editTextPartialId
+        this.editText.id = editTextIdOf(this.id)
 
         attrs?.let {
-            val styledAttributes: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.AccessCheckoutEditText, 0, 0)
+            val styledAttributes: TypedArray =
+                context.obtainStyledAttributes(attrs, R.styleable.AccessCheckoutEditText, 0, 0)
 
             val attributeValues = AttributeValues(styledAttributes)
 
@@ -46,7 +54,7 @@ class AccessCheckoutEditText internal constructor(
     }
 
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) :
-        this(context, attrs, defStyle, EditText(context))
+            this(context, attrs, defStyle, EditText(context))
 
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -27,6 +27,9 @@ class AccessCheckoutEditText internal constructor(
     internal val editText: EditText,
 ) : LinearLayout(context, attrs, defStyle) {
     internal companion object {
+        private const val SUPER_STATE_KEY = "superState"
+        private const val EDIT_TEXT_STATE_KEY = "editTextState"
+
         private val allEditTextIds = ConcurrentHashMap<Int, Int?>()
 
         fun editTextIdOf(accessCheckoutEditTextId: Int): Int {
@@ -186,15 +189,15 @@ class AccessCheckoutEditText internal constructor(
     public override fun onSaveInstanceState(): Parcelable? {
         val editTextState = editText.onSaveInstanceState()
         return Bundle().apply {
-            putParcelable("superState", super.onSaveInstanceState())
-            putParcelable("editTextState", editTextState)
+            putParcelable(SUPER_STATE_KEY, super.onSaveInstanceState())
+            putParcelable(EDIT_TEXT_STATE_KEY, editTextState)
         }
     }
 
     public override fun onRestoreInstanceState(state: Parcelable) {
         val bundledState = (state as Bundle)
 
-        super.onRestoreInstanceState(bundledState.getParcelable("superState"))
-        editText.onRestoreInstanceState(bundledState.getParcelable("editTextState"))
+        super.onRestoreInstanceState(bundledState.getParcelable(SUPER_STATE_KEY))
+        editText.onRestoreInstanceState(bundledState.getParcelable(EDIT_TEXT_STATE_KEY))
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/ExpiryDateTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/ExpiryDateTextWatcher.kt
@@ -31,6 +31,7 @@ internal class ExpiryDateTextWatcher(
                 val newExpiryDate = expiryDateSanitiser.sanitise(expiryDate)
                 if (expiryDate != newExpiryDate) {
                     updateText(newExpiryDate)
+                    clearTextBefore()
                     return
                 }
             }
@@ -38,6 +39,7 @@ internal class ExpiryDateTextWatcher(
 
         val result = dateValidator.validate(expiryDate)
         expiryDateValidationResultHandler.handleResult(isValid = result)
+        clearTextBefore()
     }
 
     private fun attemptingToDeleteSeparator(textBefore: String, textAfter: String): Boolean {
@@ -50,5 +52,12 @@ internal class ExpiryDateTextWatcher(
     private fun updateText(text: String) {
         expiryDateEditText.setText(text)
         expiryDateEditText.setSelection(text.length)
+    }
+
+    /**
+     * Designed to clear from memory the text held in the textBefore property
+     */
+    private fun clearTextBefore() {
+        this.textBefore = ""
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -82,6 +82,7 @@ internal class PanTextWatcher(
         val cardValidationRule = getPanValidationRule(brand)
 
         if (trimToMaxLength(cardValidationRule, newPan)) {
+            clearPanBefore()
             return
         }
 
@@ -98,6 +99,12 @@ internal class PanTextWatcher(
         if (panEditText.selectionEnd != expectedCursorPosition && panEditText.length() >= expectedCursorPosition) {
             panEditText.setSelection(expectedCursorPosition)
         }
+
+        clearPanBefore()
+    }
+
+    private fun clearPanBefore() {
+        this.panBefore = ""
     }
 
     /**

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -103,6 +103,9 @@ internal class PanTextWatcher(
         clearPanBefore()
     }
 
+    /**
+     * Designed to clear from memory the text held in the panBefore property
+     */
     private fun clearPanBefore() {
         this.panBefore = ""
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
@@ -6,6 +6,19 @@ import com.worldpay.access.checkout.api.serialization.Serializer
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.testutils.CoroutineTestRule
 import com.worldpay.access.checkout.testutils.removeWhitespace
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.BDDMockito.any
+import org.mockito.BDDMockito.anyInt
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.verify
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.kotlin.mock
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.Serializable
@@ -13,18 +26,7 @@ import java.net.ConnectException
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 import kotlin.test.assertTrue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest as runAsBlockingTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.mockito.BDDMockito.given
-import org.mockito.BDDMockito.verify
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.kotlin.mock
 
 @ExperimentalCoroutinesApi
 class HttpsClientTest {
@@ -52,12 +54,13 @@ class HttpsClientTest {
         serializer = mock()
         clientErrorDeserializer = mock()
         url = mock()
-        httpsClient = HttpsClient(coroutinesTestRule.testDispatcher, urlFactory, clientErrorDeserializer)
+        httpsClient =
+            HttpsClient(coroutinesTestRule.testDispatcher, urlFactory, clientErrorDeserializer)
         httpsUrlConnection = mock()
     }
 
     @Test
-    fun givenValidRequest_shouldReturnSuccessfulResponseOnPost() = runAsBlockingTest {
+    fun givenValidRequest_doPost_shouldReturnSuccessfulResponse() = runAsBlockingTest {
         val testResponseAsString = removeWhitespace(
             """{
                 "property": "abcdef"
@@ -73,56 +76,153 @@ class HttpsClientTest {
         given(serializer.serialize(testRequest)).willReturn(testRequestString)
         given(deserializer.deserialize(testResponseAsString)).willReturn(testResponse)
 
-        val response = httpsClient.doPost(url, testRequest, newHashMap(mapOf(Pair("key", "value"))), serializer, deserializer)
+        val response = httpsClient.doPost(
+            url,
+            testRequest,
+            newHashMap(mapOf(Pair("key", "value"))),
+            serializer,
+            deserializer
+        )
 
         assertEquals(testResponse, response)
         verify(httpsUrlConnection).setRequestProperty("key", "value")
     }
 
     @Test
-    fun givenErrorWhenReadingResponseBody_ThenShouldThrowAccessCheckoutExceptionOnPost() = runAsBlockingTest {
-        val errorMessage = "Some message"
+    fun givenValidRequestAndHttp201AndDeserializationException_doPost_shouldThrowAccessCheckoutExceptionWithCauseAndMessage() =
+        runAsBlockingTest {
+            val responseBody = "{}"
+            stubResponse(responseCode = 201, responseBody = responseBody)
 
-        val inputStream = Mockito.mock(InputStream::class.java) {
-            throw java.lang.RuntimeException(errorMessage)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(deserializer.deserialize(responseBody)).willThrow(RuntimeException())
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "An exception was thrown when trying to establish a connection",
+                    ace.message
+                )
+                assertTrue { ace.cause is java.lang.RuntimeException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-
-        stubResponse(responseCode = 201)
-        given(httpsUrlConnection.inputStream).willReturn(inputStream)
-
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(errorMessage, ace.message)
-            assertTrue(ace.cause is RuntimeException)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
 
     @Test
-    fun givenHttp500Error_ThenShouldThrowAccessCheckoutErrorWithDefaultMessageWhenNoResponseBodyOnPost() = runAsBlockingTest {
-        val errorMessage = "A server error occurred when trying to make the request"
+    fun givenErrorWhenReadingResponseBody_doPost_shouldThrowAccessCheckoutException() =
+        runAsBlockingTest {
+            val errorMessage = "Some message"
 
-        stubErrorResponse(responseCode = 500, message = "")
+            val inputStream = Mockito.mock(InputStream::class.java) {
+                throw java.lang.RuntimeException(errorMessage)
+            }
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            stubResponse(responseCode = 201)
+            given(httpsUrlConnection.inputStream).willReturn(inputStream)
 
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(errorMessage, ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(errorMessage, ace.message)
+                assertTrue(ace.cause is RuntimeException)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun shouldThrowExceptionWhenStatusCodeIsBelow200ForPost() = runAsBlockingTest {
+    fun givenHttp500ErrorAndNoResponseBody_doPost_shouldThrowAccessCheckoutErrorWithDefaultMessage() =
+        runAsBlockingTest {
+            val errorMessage = "A server error occurred when trying to make the request"
+
+            stubErrorResponse(responseCode = 500, message = "")
+
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(errorMessage, ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenHttp500ErrorAndBodyInResponse_doPost_shouldThrowAccessCheckoutErrorWithMessageFromServer() =
+        runAsBlockingTest {
+            stubErrorResponse(
+                responseCode = 500,
+                responseBody = "Some exception occurred",
+                message = "Some http message"
+            )
+
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Error message was: Some http message. Error response was: Some exception occurred",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenHttp500ErrorWithResponseBody_doPost_shouldThrowAccessCheckoutExceptionWithErrorResponseFromServer() =
+        runAsBlockingTest {
+            val errorMessage = "some error message"
+            stubErrorResponse(responseCode = 500, responseBody = "", message = errorMessage)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals("Error message was: $errorMessage", ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenHttp500ErrorAndExceptionIsThrownWhenReadingErrorStream_doPost_shouldThrowAccessCheckoutExceptionWithThatErrorResponseFromServer() =
+        runAsBlockingTest {
+            val expectedException = RuntimeException("some unhandled exception")
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            given(url.openConnection()).willReturn(httpsUrlConnection)
+            given(httpsUrlConnection.responseCode).willReturn(500)
+            given(httpsUrlConnection.outputStream).willReturn(ByteArrayOutputStream())
+
+            val mockErrorStream = mock<InputStream>()
+            given(mockErrorStream.read(any(), anyInt(), anyInt())).willThrow(expectedException)
+            given(httpsUrlConnection.errorStream).willReturn(mockErrorStream)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ex: AccessCheckoutException) {
+                assertEquals(expectedException.message, ex.message)
+                assertEquals(expectedException, ex.cause)
+            } catch (ex: RuntimeException) {
+                fail("Expected RuntimeException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenHttpStatusCodeBelow200_doPost_shouldThrowException() = runAsBlockingTest {
         val errorMessage = "A server error occurred when trying to make the request"
 
         stubErrorResponse(responseCode = 100, message = "")
@@ -140,25 +240,10 @@ class HttpsClientTest {
     }
 
     @Test
-    fun givenHttp500Error_ThenShouldThrowAccessCheckoutErrorWithMessageFromServerWhenBodyInResponseOnPost() = runAsBlockingTest {
-        stubErrorResponse(responseCode = 500, responseBody = "Some exception occurred", message = "Some http message")
-
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Error message was: Some http message. Error response was: Some exception occurred", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
-
-    @Test
-    fun givenHttp400ErrorWithResponseBody_ThenShouldThrowAccessCheckoutExceptionWithErrorResponseFromServerOnPost() =
+    fun givenHttp400ErrorWithResponseBody_doPost_shouldThrowAccessCheckoutExceptionWithErrorResponseFromServer() =
         runAsBlockingTest {
-            val errorMessage = "bodyDoesNotMatchSchema : The json body provided does not match the expected schema"
+            val errorMessage =
+                "bodyDoesNotMatchSchema : The json body provided does not match the expected schema"
             val responseBody =
                 removeWhitespace(
                     """{
@@ -174,8 +259,14 @@ class HttpsClientTest {
                         }"""
                 )
 
-            stubErrorResponse(responseCode = 400, responseBody = responseBody, message = errorMessage)
-            given(clientErrorDeserializer.deserialize(responseBody)).willThrow(AccessCheckoutException(errorMessage))
+            stubErrorResponse(
+                responseCode = 400,
+                responseBody = responseBody,
+                message = errorMessage
+            )
+            given(clientErrorDeserializer.deserialize(responseBody)).willThrow(
+                AccessCheckoutException(errorMessage)
+            )
 
             given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
@@ -190,103 +281,92 @@ class HttpsClientTest {
         }
 
     @Test
-    fun givenHttp400ErrorWithNoResponseBody_ThenShouldThrowAccessCheckoutExceptionWithoutAnyErrorResponseBodyOnPost() = runAsBlockingTest {
-        val errorMessage = "bodyIsEmpty : The body within the request is empty"
-        val expectedException = AccessCheckoutException(errorMessage)
+    fun givenHttp400ErrorWithNoResponseBody_doPost_shouldThrowAccessCheckoutExceptionWithoutAnyErrorResponseBody() =
+        runAsBlockingTest {
+            val errorMessage = "bodyIsEmpty : The body within the request is empty"
+            val expectedException = AccessCheckoutException(errorMessage)
 
-        val jsonResponse = removeWhitespace(
-            """{
+            val jsonResponse = removeWhitespace(
+                """{
                                 "errorName": "bodyIsEmpty",
                                 "message": "$errorMessage"
                             }"""
-        )
-
-        stubErrorResponse(responseCode = 400, responseBody = jsonResponse, message = errorMessage)
-        given(clientErrorDeserializer.deserialize(jsonResponse)).willReturn(expectedException)
-
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(errorMessage, ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
-
-    @Test
-    fun givenHttp400ErrorWithEmptyResponseData_ThenShouldThrowAccessCheckoutHttpExceptionWithoutAnyErrorResponseBodyOnPost() = runAsBlockingTest {
-        stubErrorResponse(responseCode = 400, message = "Some Client Error")
-        val errorMessage = "Error message was: Some Client Error"
-
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(errorMessage, ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
-
-    @Test
-    fun givenServerCannotBeReached_ThenShouldThrowAccessCheckoutExceptionWithCauseOnPost() = runAsBlockingTest {
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-        given(url.openConnection()).willThrow(ConnectException())
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertTrue { ace.cause is ConnectException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
-
-    @Test
-    fun givenSerializationException_ThenShouldThrowAccessCheckoutExceptionWithCauseAndMessageOnPost() = runAsBlockingTest {
-        given(serializer.serialize(testRequest)).willThrow(RuntimeException())
-
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(
-                "An exception was thrown when trying to establish a connection",
-                ace.message
             )
-            assertTrue { ace.cause is java.lang.RuntimeException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+
+            stubErrorResponse(
+                responseCode = 400,
+                responseBody = jsonResponse,
+                message = errorMessage
+            )
+            given(clientErrorDeserializer.deserialize(jsonResponse)).willReturn(expectedException)
+
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(errorMessage, ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenDeserializationException_ThenShouldThrowAccessCheckoutExceptionWithCauseAndMessageOnPost() = runAsBlockingTest {
-        val responseBody = "{}"
-        stubResponse(responseCode = 201, responseBody = responseBody)
+    fun givenHttp400ErrorWithEmptyResponseData_doPost_shouldThrowAccessCheckoutHttpExceptionWithoutAnyErrorResponseBody() =
+        runAsBlockingTest {
+            stubErrorResponse(responseCode = 400, message = "Some Client Error")
+            val errorMessage = "Error message was: Some Client Error"
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
-        given(deserializer.deserialize(responseBody)).willThrow(RuntimeException())
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("An exception was thrown when trying to establish a connection", ace.message)
-            assertTrue { ace.cause is java.lang.RuntimeException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(errorMessage, ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenRedirectSentByServer_ThenShouldFollowRedirectOnPost() = runAsBlockingTest {
+    fun givenServerCannotBeReached_doPost_shouldThrowAccessCheckoutExceptionWithCause() =
+        runAsBlockingTest {
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(url.openConnection()).willThrow(ConnectException())
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertTrue { ace.cause is ConnectException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenSerializationException_doPost_shouldThrowAccessCheckoutExceptionWithCauseAndMessage() =
+        runAsBlockingTest {
+            given(serializer.serialize(testRequest)).willThrow(RuntimeException())
+
+            try {
+                httpsClient.doPost(url, testRequest, newHashMap(), serializer, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "An exception was thrown when trying to establish a connection",
+                    ace.message
+                )
+                assertTrue { ace.cause is java.lang.RuntimeException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
+        }
+
+    @Test
+    fun givenRedirectSentByServer_doPost_shouldFollowRedirect() = runAsBlockingTest {
         val testResponseAsString = removeWhitespace(
             """{
                 "property": "abcdef"
@@ -314,53 +394,79 @@ class HttpsClientTest {
         given(serializer.serialize(testRequest)).willReturn(testRequestString)
         given(deserializer.deserialize(testResponseAsString)).willReturn(testResponse)
 
-        val response = httpsClient.doPost(url, testRequest, newHashMap(mapOf(Pair("key", "value"))), serializer, deserializer)
+        val response = httpsClient.doPost(
+            url,
+            testRequest,
+            newHashMap(mapOf(Pair("key", "value"))),
+            serializer,
+            deserializer
+        )
 
         assertEquals(testResponse, response)
     }
 
     @Test
-    fun givenRedirectSentWithNoLocationHeaderByServer_ThenShouldThrowAccessCheckoutHttpExceptionOnPost() = runAsBlockingTest {
-        stubResponse(responseCode = 301)
+    fun givenRedirectSentWithNoLocationHeaderByServer_doPost_shouldThrowAccessCheckoutHttpException() =
+        runAsBlockingTest {
+            stubResponse(responseCode = 301)
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(mapOf(Pair("key", "value"))), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Response from server was a redirect HTTP response code: 301 but did not include a Location header", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doPost(
+                    url,
+                    testRequest,
+                    newHashMap(mapOf(Pair("key", "value"))),
+                    serializer,
+                    deserializer
+                )
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Response from server was a redirect HTTP response code: 301 but did not include a Location header",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenRedirectSentWithEmptyLocationHeaderByServer_ThenShouldThrowAccessCheckoutHttpExceptionOnPost() = runAsBlockingTest {
-        val redirectResponseCode = 301
+    fun givenRedirectSentWithEmptyLocationHeaderByServer_doPost_shouldThrowAccessCheckoutHttpException() =
+        runAsBlockingTest {
+            val redirectResponseCode = 301
 
-        given(url.openConnection()).willReturn(httpsUrlConnection)
-        given(httpsUrlConnection.responseCode).willReturn(301)
-        given(httpsUrlConnection.inputStream).willReturn(null)
-        given(httpsUrlConnection.errorStream).willReturn(null)
-        given(httpsUrlConnection.outputStream).willReturn(ByteArrayOutputStream())
-        given(httpsUrlConnection.responseMessage).willReturn("")
-        given(httpsUrlConnection.getHeaderField("Location")).willReturn("")
+            given(url.openConnection()).willReturn(httpsUrlConnection)
+            given(httpsUrlConnection.responseCode).willReturn(301)
+            given(httpsUrlConnection.inputStream).willReturn(null)
+            given(httpsUrlConnection.errorStream).willReturn(null)
+            given(httpsUrlConnection.outputStream).willReturn(ByteArrayOutputStream())
+            given(httpsUrlConnection.responseMessage).willReturn("")
+            given(httpsUrlConnection.getHeaderField("Location")).willReturn("")
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doPost(url, testRequest, newHashMap(mapOf(Pair("key", "value"))), serializer, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Response from server was a redirect HTTP response code: $redirectResponseCode but did not include a Location header", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doPost(
+                    url,
+                    testRequest,
+                    newHashMap(mapOf(Pair("key", "value"))),
+                    serializer,
+                    deserializer
+                )
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Response from server was a redirect HTTP response code: $redirectResponseCode but did not include a Location header",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenValidRequest_shouldReturnSuccessfulResponseOnGet() = runAsBlockingTest {
+    fun givenValidRequest_doGet_shouldReturnSuccessfulResponse() = runAsBlockingTest {
 
         val testResponseAsString = removeWhitespace(
             """{
@@ -380,33 +486,34 @@ class HttpsClientTest {
     }
 
     @Test
-    fun givenErrorWhenReadingResponseBody_ThenShouldThrowAccessCheckoutExceptionOnGet() = runAsBlockingTest {
-        val errorMessage = "Some message"
+    fun givenErrorWhenReadingResponseBody_doGet_shouldThrowAccessCheckoutException() =
+        runAsBlockingTest {
+            val errorMessage = "Some message"
 
-        val inputStream = Mockito.mock(InputStream::class.java) {
-            throw java.lang.RuntimeException(errorMessage)
+            val inputStream = Mockito.mock(InputStream::class.java) {
+                throw java.lang.RuntimeException(errorMessage)
+            }
+
+            given(url.openConnection()).willReturn(httpsUrlConnection)
+            given(httpsUrlConnection.responseCode).willReturn(201)
+            given(httpsUrlConnection.inputStream).willReturn(inputStream)
+            given(httpsUrlConnection.errorStream).willReturn(inputStream)
+            given(httpsUrlConnection.outputStream).willReturn(ByteArrayOutputStream())
+            given(httpsUrlConnection.responseMessage).willReturn("")
+
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(errorMessage, ace.message)
+                assertTrue { ace.cause is RuntimeException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-
-        given(url.openConnection()).willReturn(httpsUrlConnection)
-        given(httpsUrlConnection.responseCode).willReturn(201)
-        given(httpsUrlConnection.inputStream).willReturn(inputStream)
-        given(httpsUrlConnection.errorStream).willReturn(inputStream)
-        given(httpsUrlConnection.outputStream).willReturn(ByteArrayOutputStream())
-        given(httpsUrlConnection.responseMessage).willReturn("")
-
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals(errorMessage, ace.message)
-            assertTrue { ace.cause is RuntimeException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
-        }
-    }
 
     @Test
-    fun shouldThrowExceptionWhenStatusCodeIsBelow200ForGet() = runAsBlockingTest {
+    fun givenHttpStatusCodeBelow200_doGet_shouldThrowException() = runAsBlockingTest {
         val errorMessage = "A server error occurred when trying to make the request"
 
         stubErrorResponse(responseCode = 100, message = "")
@@ -422,39 +529,49 @@ class HttpsClientTest {
     }
 
     @Test
-    fun givenHttp500Error_ThenShouldThrowAccessCheckoutErrorWithDefaultMessageWhenNoResponseBodyOnGet() = runAsBlockingTest {
-        stubErrorResponse(responseCode = 500)
+    fun givenHttp500Error_doGet_shouldThrowAccessCheckoutErrorWithDefaultMessageWhenNoResponseBody() =
+        runAsBlockingTest {
+            stubErrorResponse(responseCode = 500)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("A server error occurred when trying to make the request", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals("A server error occurred when trying to make the request", ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenHttp500Error_ThenShouldThrowAccessCheckoutErrorWithMessageFromServerWhenBodyInResponseOnGet() = runAsBlockingTest {
-        stubErrorResponse(responseCode = 500, responseBody = "Some exception occurred", message = "Some http message")
+    fun givenHttp500Error_doGet_shouldThrowAccessCheckoutErrorWithMessageFromServerWhenBodyInResponse() =
+        runAsBlockingTest {
+            stubErrorResponse(
+                responseCode = 500,
+                responseBody = "Some exception occurred",
+                message = "Some http message"
+            )
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Error message was: Some http message. Error response was: Some exception occurred", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Error message was: Some http message. Error response was: Some exception occurred",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenHttp400ErrorWithResponseBody_ThenShouldThrowAccessCheckoutExceptionWithErrorResponseFromServerOnGet() = runAsBlockingTest {
-        val errorMessage = "The json body provided does not match the expected schema"
-        val responseBody = """{
+    fun givenHttp400ErrorWithResponseBody_doGet_shouldThrowAccessCheckoutExceptionWithErrorResponseFromServer() =
+        runAsBlockingTest {
+            val errorMessage = "The json body provided does not match the expected schema"
+            val responseBody = """{
                                 "errorName": "bodyDoesNotMatchSchema",
                                 "message": "The json body provided does not match the expected schema",
                                 "validationErrors": [
@@ -466,81 +583,99 @@ class HttpsClientTest {
                                 ]
                             }"""
 
-        stubErrorResponse(responseCode = 400, responseBody = responseBody, message = errorMessage)
+            stubErrorResponse(
+                responseCode = 400,
+                responseBody = responseBody,
+                message = errorMessage
+            )
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Error message was: $errorMessage. Error response was: ${responseBody.replace("\n", "")}", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Error message was: $errorMessage. Error response was: ${
+                        responseBody.replace(
+                            "\n",
+                            ""
+                        )
+                    }", ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenHttp400ErrorWithNoResponseBody_ThenShouldThrowAccessCheckoutExceptionWithoutAnyErrorResponseBodyOnGet() = runAsBlockingTest {
-        val errorMessage = "Cannot deserialize empty string"
+    fun givenHttp400ErrorWithNoResponseBody_doGet_shouldThrowAccessCheckoutExceptionWithoutAnyErrorResponseBody() =
+        runAsBlockingTest {
+            val errorMessage = "Cannot deserialize empty string"
 
-        stubErrorResponse(responseCode = 400, responseBody = "", message = errorMessage)
+            stubErrorResponse(responseCode = 400, responseBody = "", message = errorMessage)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Error message was: $errorMessage", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals("Error message was: $errorMessage", ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenHttp400ErrorWithEmptyResponseData_ThenShouldThrowAccessCheckoutHttpExceptionWithoutAnyErrorResponseBodyOnGet() = runAsBlockingTest {
-        stubErrorResponse(responseCode = 400, message = "Some Client Error")
+    fun givenHttp400ErrorWithEmptyResponseData_doGet_shouldThrowAccessCheckoutHttpExceptionWithoutAnyErrorResponseBody() =
+        runAsBlockingTest {
+            stubErrorResponse(responseCode = 400, message = "Some Client Error")
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Error message was: Some Client Error", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals("Error message was: Some Client Error", ace.message)
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenServerCannotBeReached_ThenShouldThrowAccessCheckoutExceptionWithCauseOnGet() = runAsBlockingTest {
-        given(url.openConnection()).willThrow(ConnectException())
+    fun givenServerCannotBeReached_doGet_shouldThrowAccessCheckoutExceptionWithCause() =
+        runAsBlockingTest {
+            given(url.openConnection()).willThrow(ConnectException())
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertTrue { ace.cause is ConnectException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertTrue { ace.cause is ConnectException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenDeserializationException_ThenShouldThrowAccessCheckoutExceptionWithCauseAndMessageOnGet() = runAsBlockingTest {
-        val responseBody = "{}"
-        stubResponse(responseCode = 201, responseBody = responseBody)
+    fun givenDeserializationException_doGet_shouldThrowAccessCheckoutExceptionWithCauseAndMessage() =
+        runAsBlockingTest {
+            val responseBody = "{}"
+            stubResponse(responseCode = 201, responseBody = responseBody)
 
-        given(deserializer.deserialize(responseBody)).willThrow(RuntimeException())
+            given(deserializer.deserialize(responseBody)).willThrow(RuntimeException())
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("An exception was thrown when trying to establish a connection", ace.message)
-            assertTrue { ace.cause is java.lang.RuntimeException }
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "An exception was thrown when trying to establish a connection",
+                    ace.message
+                )
+                assertTrue { ace.cause is java.lang.RuntimeException }
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
     fun givenRedirectSentByServer_ThenShouldFollowRedirectOnGet() = runAsBlockingTest {
@@ -573,40 +708,48 @@ class HttpsClientTest {
     }
 
     @Test
-    fun givenRedirectSentWithNoLocationHeaderByServer_ThenShouldThrowAccessCheckoutHttpExceptionOnGet() = runAsBlockingTest {
-        val redirectResponseCode = 301
+    fun givenRedirectSentWithNoLocationHeaderByServer_doGet_shouldThrowAccessCheckoutHttpException() =
+        runAsBlockingTest {
+            val redirectResponseCode = 301
 
-        given(url.openConnection()).willReturn(httpsUrlConnection)
-        given(httpsUrlConnection.responseCode).willReturn(redirectResponseCode)
+            given(url.openConnection()).willReturn(httpsUrlConnection)
+            given(httpsUrlConnection.responseCode).willReturn(redirectResponseCode)
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Response from server was a redirect HTTP response code: $redirectResponseCode but did not include a Location header", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Response from server was a redirect HTTP response code: $redirectResponseCode but did not include a Location header",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     @Test
-    fun givenRedirectSentWithEmptyLocationHeaderByServer_ThenShouldThrowAccessCheckoutHttpExceptionOnGet() = coroutinesTestRule.testDispatcher.runAsBlockingTest {
-        stubResponse(responseCode = 301)
-        given(httpsUrlConnection.getHeaderField("Location")).willReturn("")
+    fun givenRedirectSentWithEmptyLocationHeaderByServer_doGet_shouldThrowAccessCheckoutHttpException() =
+        coroutinesTestRule.testDispatcher.runAsBlockingTest {
+            stubResponse(responseCode = 301)
+            given(httpsUrlConnection.getHeaderField("Location")).willReturn("")
 
-        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+            given(serializer.serialize(testRequest)).willReturn(testRequestString)
 
-        try {
-            httpsClient.doGet(url, deserializer)
-            fail("Expected exception but got none")
-        } catch (ace: AccessCheckoutException) {
-            assertEquals("Response from server was a redirect HTTP response code: 301 but did not include a Location header", ace.message)
-        } catch (ex: Exception) {
-            fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            try {
+                httpsClient.doGet(url, deserializer)
+                fail("Expected exception but got none")
+            } catch (ace: AccessCheckoutException) {
+                assertEquals(
+                    "Response from server was a redirect HTTP response code: 301 but did not include a Location header",
+                    ace.message
+                )
+            } catch (ex: Exception) {
+                fail("Expected AccessCheckoutException but got " + ex.javaClass.simpleName)
+            }
         }
-    }
 
     private fun stubErrorResponse(
         url: URL = this.url,

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -5,12 +5,14 @@ import android.content.res.TypedArray
 import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Bundle
+import android.os.Parcelable
 import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
 import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
+import android.view.AbsSavedState
 import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
@@ -508,10 +510,11 @@ class AccessCheckoutEditTextTest {
     }
 
     @Test
-    fun `onRestoreInstanceState() should call EditText onRestoreInstanceState()`() {
+    fun `onRestoreInstanceState() should call EditText onRestoreInstanceState() using key used to save EditText state`() {
+        val editTextState = mock<AbsSavedState>()
+
         val bundledState = mock<Bundle>()
-        val editTextState = mock<Bundle>()
-        given(bundledState.getBundle("editTextState")).willReturn(editTextState)
+        given(bundledState.getParcelable<Parcelable>("editTextState")).willReturn(editTextState)
 
         accessCheckoutEditText.onRestoreInstanceState(bundledState)
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -85,7 +85,9 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set hint from attribute set`() {
-        given(typedArrayMock.getString(eq(R.styleable.AccessCheckoutEditText_android_hint))).willReturn("some-hint")
+        given(typedArrayMock.getString(eq(R.styleable.AccessCheckoutEditText_android_hint))).willReturn(
+            "some-hint"
+        )
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -94,7 +96,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set ems from attribute set`() {
-        given(typedArrayMock.getInt(eq(R.styleable.AccessCheckoutEditText_android_ems), eq(0))).willReturn(123)
+        given(
+            typedArrayMock.getInt(
+                eq(R.styleable.AccessCheckoutEditText_android_ems),
+                eq(0)
+            )
+        ).willReturn(123)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -103,7 +110,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set hintTextColor from attribute set`() {
-        given(typedArrayMock.getColor(eq(R.styleable.AccessCheckoutEditText_android_textColorHint), eq(0))).willReturn(
+        given(
+            typedArrayMock.getColor(
+                eq(R.styleable.AccessCheckoutEditText_android_textColorHint),
+                eq(0)
+            )
+        ).willReturn(
             Color.GREEN
         )
 
@@ -114,7 +126,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set imeOptions from attribute set`() {
-        given(typedArrayMock.getInt(eq(R.styleable.AccessCheckoutEditText_android_imeOptions), eq(0))).willReturn(123)
+        given(
+            typedArrayMock.getInt(
+                eq(R.styleable.AccessCheckoutEditText_android_imeOptions),
+                eq(0)
+            )
+        ).willReturn(123)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -137,7 +154,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set textScale from attribute set`() {
-        given(typedArrayMock.getFloat(eq(R.styleable.AccessCheckoutEditText_android_textScaleX), eq(0F))).willReturn(1F)
+        given(
+            typedArrayMock.getFloat(
+                eq(R.styleable.AccessCheckoutEditText_android_textScaleX),
+                eq(0F)
+            )
+        ).willReturn(1F)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -146,7 +168,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set textSize from attribute set`() {
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_textSize), eq(0F))).willReturn(1F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_textSize),
+                eq(0F)
+            )
+        ).willReturn(1F)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -155,7 +182,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set padding from attribute set`() {
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_padding), eq(0.0F))).willReturn(1F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_padding),
+                eq(0.0F)
+            )
+        ).willReturn(1F)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -164,10 +196,30 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `should set padding left, top, right, bottom from attribute set`() {
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_paddingLeft), eq(0.0F))).willReturn(1F)
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_paddingTop), eq(0.0F))).willReturn(2F)
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_paddingRight), eq(0.0F))).willReturn(3F)
-        given(typedArrayMock.getDimension(eq(R.styleable.AccessCheckoutEditText_android_paddingBottom), eq(0.0F))).willReturn(4F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_paddingLeft),
+                eq(0.0F)
+            )
+        ).willReturn(1F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_paddingTop),
+                eq(0.0F)
+            )
+        ).willReturn(2F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_paddingRight),
+                eq(0.0F)
+            )
+        ).willReturn(3F)
+        given(
+            typedArrayMock.getDimension(
+                eq(R.styleable.AccessCheckoutEditText_android_paddingBottom),
+                eq(0.0F)
+            )
+        ).willReturn(4F)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -178,7 +230,9 @@ class AccessCheckoutEditTextTest {
     fun `should set font from attribute set`() {
         val typefaceMock: Typeface = mock()
 
-        given(typedArrayMock.getFont(eq(R.styleable.AccessCheckoutEditText_android_font))).willReturn(typefaceMock)
+        given(typedArrayMock.getFont(eq(R.styleable.AccessCheckoutEditText_android_font))).willReturn(
+            typefaceMock
+        )
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
@@ -188,11 +242,6 @@ class AccessCheckoutEditTextTest {
     /**
      * Properties tests
      */
-    @Test
-    fun `companion object has an editTextPartialId field`() {
-        assertNotNull(AccessCheckoutEditText.editTextPartialId)
-    }
-
     @Test
     fun `text should return EditText text`() {
         val editable = mock<Editable>()
@@ -408,7 +457,7 @@ class AccessCheckoutEditTextTest {
     }
 
     /**
-     Methods tests
+    Methods tests
      */
     @Test
     fun `length() should return EditText length`() {

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
+import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
 import android.view.KeyEvent
@@ -16,6 +17,7 @@ import android.widget.EditText
 import com.worldpay.access.checkout.R
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
@@ -417,11 +419,12 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `clear() should clear EditText text`() {
-        val editableMock = mock<Editable>()
-        given(editTextMock.text).willReturn(editableMock)
+        val argumentCaptor = ArgumentCaptor.forClass(SpannableStringBuilder::class.java)
 
         accessCheckoutEditText.clear()
-        verify(editableMock).clear()
+
+        verify(accessCheckoutEditText.editText).text = argumentCaptor.capture()
+        assertEquals(0, argumentCaptor.value.length)
     }
 
     @Test

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -244,7 +244,6 @@ workflows:
             - test_type: instrumentation
             - test_apk_path: "$BITRISE_TEST_APK"
             - test_timeout: 1500
-            - num_flaky_test_attempts: 1
             - test_devices: |-
                 Pixel2,26,en,portrait
                 Pixel2,27,en,portrait

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -244,6 +244,7 @@ workflows:
             - test_type: instrumentation
             - test_apk_path: "$BITRISE_TEST_APK"
             - test_timeout: 1500
+            - download_test_results: true
             - test_devices: |-
                 Pixel2,26,en,portrait
                 Pixel2,27,en,portrait
@@ -252,6 +253,12 @@ workflows:
                 Pixel2.arm,30,en,portrait
                 Pixel2.arm,32,en,portrait
                 Pixel2.arm,33,en,portrait
+      - deploy-to-bitrise-io@2.1.4:
+          title: "Export code coverage results to Bitrise"
+          inputs:
+            - is_compress: 'true'
+            - zip_name: ui-test-results
+            - deploy_path: "$VDTESTING_DOWNLOADED_FILES_DIR"
       - cache-push@2.7.1: { }
 
 app:


### PR DESCRIPTION
## What
- fix memory leak in `PanTextWatcher` and `ExpiryDateTextWatcher` where previous state of text entered by the user remains in memory during typing
- fix memory leak in `AccessCheckoutEditText` `clear()` method where text entered by user remains in heap despite clearing it
- fix memory leaks in `HttpsClient` where request to backend remained in memory after generating sessions. And closed all `*Stream*` and `*Reader` classes that were not properly closed.

## How
- the leak in `PanTextWatcher` and `ExpiryDateTextWatcher`has been fixed by clearing respectively `panBefore` and `textBefore` at the end of the text change flow to ensure they don't remain in memory
- the lealk in `AccessCheckoutEditText` `clear()` was due to the fact that the `SpannableStringBuilder` class used under the hood to manipulate the text in the native `EditText` does not clear its memory correctly when cleared. The fix is to assign the `EditText` `text` property with a new instance of `SpannableStringBuilder`
- the 1st memory leak in `HttpsClient` has been fixed by setting the `Connection` header of every request to `close` as it is `keep-alive` by default in the java libraries used under the hood. This instructs the library to not re-use connections and close them after each request. The impact on performances should be marginal. The 2nd memory leak has been fixed by disabling the `chunkedStreamingMode` on POST requests as it seems to keep in memory request bodies. This should not be a problem performance-wise given that our requests payloads are very small.

## Why
- these changes fix issues where a merchant app could be vulnerable to heap inspection attacks