### PR TITLE
US1776896 - remove weak ciphers from list of ciphers presented by HttpsClient during SSL handshake

### DIFF
--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/ssl/client/TrustAllSSLSocketFactory.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/ssl/client/TrustAllSSLSocketFactory.kt
@@ -7,6 +7,7 @@ import java.net.Socket
 import java.net.UnknownHostException
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
@@ -16,6 +17,8 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     private val sslContext = SSLContext.getInstance("TLS")
 
     companion object {
+        private val DEFAULT_CIPHER_SUITES = HttpsURLConnection.getDefaultSSLSocketFactory().defaultCipherSuites
+
         val X509_TRUST_MANAGER = object : X509TrustManager {
             @SuppressLint("TrustAllX509TrustManager")
             override fun checkClientTrusted(xcs: Array<X509Certificate?>?, string: String?) {
@@ -36,7 +39,7 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     }
 
     override fun getDefaultCipherSuites(): Array<String> {
-        return emptyArray()
+        return DEFAULT_CIPHER_SUITES
     }
 
     @Throws(IOException::class, UnknownHostException::class)

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
@@ -1,0 +1,85 @@
+package com.worldpay.access.checkout.api
+
+import java.net.InetAddress
+import java.net.Socket
+import java.util.Arrays
+import java.util.stream.Collectors.toList
+import javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+internal class NoWeakCipherSSLSocketFactory constructor(
+    private val defaultSSLSocketFactory: SSLSocketFactory = getDefaultSSLSocketFactory()
+) : SSLSocketFactory() {
+
+    private val enabledCipherSuites: Array<String> = Arrays
+        .stream(defaultSSLSocketFactory.defaultCipherSuites)
+        .filter { !it.endsWith("SHA", ignoreCase = true) }
+        .collect(toList())
+        .toTypedArray()
+
+    companion object {
+        private val noWeakCipherSSLSocketFactory =
+            NoWeakCipherSSLSocketFactory(getDefaultSSLSocketFactory())
+
+        internal fun noWeakCipherSSLSocketFactory(): SSLSocketFactory {
+            return noWeakCipherSSLSocketFactory
+        }
+    }
+
+    override fun createSocket(s: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
+        val socket = defaultSSLSocketFactory.createSocket(s, host, port, autoClose)
+        (socket as SSLSocket).enabledCipherSuites = enabledCipherSuites
+        return socket
+    }
+
+    override fun createSocket(host: String?, port: Int): Socket {
+        val socket = defaultSSLSocketFactory.createSocket(host, port)
+        (socket as SSLSocket).enabledCipherSuites = enabledCipherSuites
+        return socket
+    }
+
+    override fun createSocket(
+        host: String?,
+        port: Int,
+        localHost: InetAddress?,
+        localPort: Int
+    ): Socket {
+        val socket = defaultSSLSocketFactory.createSocket(host, port, localHost, localPort)
+        (socket as SSLSocket).enabledCipherSuites = enabledCipherSuites
+        return socket
+    }
+
+    override fun createSocket(host: InetAddress?, port: Int): Socket {
+        val socket = defaultSSLSocketFactory.createSocket(host, port)
+        (socket as SSLSocket).enabledCipherSuites = enabledCipherSuites
+        return socket
+    }
+
+    override fun createSocket(
+        address: InetAddress?,
+        port: Int,
+        localAddress: InetAddress?,
+        localPort: Int
+    ): Socket {
+        val socket =
+            defaultSSLSocketFactory.createSocket(address, port, localAddress, localPort)
+        (socket as SSLSocket).enabledCipherSuites = enabledCipherSuites
+        return socket
+    }
+
+    /**
+     * This method is unused as it's the Socket's enabledCiperSuites that matter
+     * but it is overridden for consistency
+     */
+    override fun getDefaultCipherSuites(): Array<String> {
+        return enabledCipherSuites
+    }
+
+    /**
+     * This method is unused but is overridden for consistency
+     */
+    override fun getSupportedCipherSuites(): Array<String> {
+        return enabledCipherSuites
+    }
+}

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
@@ -9,7 +9,7 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 
 internal class NoWeakCipherSSLSocketFactory constructor(
-    private val defaultSSLSocketFactory: SSLSocketFactory = getDefaultSSLSocketFactory()
+    private val defaultSSLSocketFactory: SSLSocketFactory
 ) : SSLSocketFactory() {
 
     private val enabledCipherSuites: Array<String> = Arrays
@@ -19,11 +19,8 @@ internal class NoWeakCipherSSLSocketFactory constructor(
         .toTypedArray()
 
     companion object {
-        private val noWeakCipherSSLSocketFactory =
-            NoWeakCipherSSLSocketFactory(getDefaultSSLSocketFactory())
-
         internal fun noWeakCipherSSLSocketFactory(): SSLSocketFactory {
-            return noWeakCipherSSLSocketFactory
+            return NoWeakCipherSSLSocketFactory(getDefaultSSLSocketFactory())
         }
     }
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -42,9 +42,9 @@ class AccessCheckoutEditText internal constructor(
 
     init {
         orientation = VERTICAL
-        super.setPadding(0,0,0,0)
+        super.setPadding(0, 0, 0, 0)
 
-        this.editText?.let { editText->
+        this.editText?.let { editText ->
             editText.id = editTextIdOf(this.id)
 
             attrs?.let {
@@ -62,7 +62,7 @@ class AccessCheckoutEditText internal constructor(
     }
 
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) :
-            this(context, attrs, defStyle, EditText(context))
+        this(context, attrs, defStyle, EditText(context))
 
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
@@ -26,7 +26,6 @@ internal class AttributeValues(
         setPaddingAttribute(editText)
 
         setFontAttribute(editText)
-
     }
 
     private fun setPaddingAttribute(editText: EditText) {

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
@@ -1,7 +1,6 @@
 package com.worldpay.access.checkout.api
 
 import com.google.common.collect.Maps.newHashMap
-import com.worldpay.access.checkout.api.NoWeakCipherSSLSocketFactory.Companion.noWeakCipherSSLSocketFactory
 import com.worldpay.access.checkout.api.serialization.Deserializer
 import com.worldpay.access.checkout.api.serialization.Serializer
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
@@ -105,7 +104,7 @@ class HttpsClientTest {
 
         httpsClient.doPost(url, testRequest, emptyMap(), serializer, deserializer)
 
-        verify(httpsUrlConnection).sslSocketFactory = noWeakCipherSSLSocketFactory()
+        verify(httpsUrlConnection).sslSocketFactory = any(NoWeakCipherSSLSocketFactory::class.java)
     }
 
     @Test
@@ -525,7 +524,7 @@ class HttpsClientTest {
 
         httpsClient.doGet(url, deserializer)
 
-        verify(httpsUrlConnection).sslSocketFactory = noWeakCipherSSLSocketFactory()
+        verify(httpsUrlConnection).sslSocketFactory = any(NoWeakCipherSSLSocketFactory::class.java)
     }
 
     @Test

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/HttpsClientTest.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.api
 
 import com.google.common.collect.Maps.newHashMap
+import com.worldpay.access.checkout.api.NoWeakCipherSSLSocketFactory.Companion.noWeakCipherSSLSocketFactory
 import com.worldpay.access.checkout.api.serialization.Deserializer
 import com.worldpay.access.checkout.api.serialization.Serializer
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
@@ -59,6 +60,9 @@ class HttpsClientTest {
         httpsUrlConnection = mock()
     }
 
+    /**
+     * doPost() tests
+     */
     @Test
     fun givenValidRequest_doPost_shouldReturnSuccessfulResponse() = runAsBlockingTest {
         val testResponseAsString = removeWhitespace(
@@ -86,6 +90,22 @@ class HttpsClientTest {
 
         assertEquals(testResponse, response)
         verify(httpsUrlConnection).setRequestProperty("key", "value")
+    }
+
+    @Test
+    fun givenValidRequest_doPost_shouldNotUseWeakCiphers() = runAsBlockingTest {
+        val testResponseAsString = removeWhitespace("{}")
+
+        stubResponse(responseCode = 201, responseBody = testResponseAsString)
+
+        assertTrue(httpsUrlConnection.requestProperties.isEmpty())
+
+        given(serializer.serialize(testRequest)).willReturn(testRequestString)
+        given(deserializer.deserialize(testResponseAsString)).willReturn(TestResponse(""))
+
+        httpsClient.doPost(url, testRequest, emptyMap(), serializer, deserializer)
+
+        verify(httpsUrlConnection).sslSocketFactory = noWeakCipherSSLSocketFactory()
     }
 
     @Test
@@ -465,6 +485,9 @@ class HttpsClientTest {
             }
         }
 
+    /**
+     * doGet() tests
+     */
     @Test
     fun givenValidRequest_doGet_shouldReturnSuccessfulResponse() = runAsBlockingTest {
 
@@ -483,6 +506,26 @@ class HttpsClientTest {
         val response = httpsClient.doGet(url, deserializer)
 
         assertEquals(testResponse, response)
+    }
+
+    @Test
+    fun givenValidRequest_doGet_shouldNotUseWeakCiphers() = runAsBlockingTest {
+
+        val testResponseAsString = removeWhitespace(
+            """{
+                "property": "abcdef"
+                }"""
+        )
+
+        val testResponse = TestResponse("abcdef")
+
+        stubResponse(responseCode = 201, responseBody = testResponseAsString)
+
+        given(deserializer.deserialize(testResponseAsString)).willReturn(testResponse)
+
+        httpsClient.doGet(url, deserializer)
+
+        verify(httpsUrlConnection).sslSocketFactory = noWeakCipherSSLSocketFactory()
     }
 
     @Test

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactoryTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactoryTest.kt
@@ -1,0 +1,177 @@
+package com.worldpay.access.checkout.api
+
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+
+class NoWeakCipherSSLSocketFactoryTest {
+    private val TEST_CIPHER_SUITES = arrayOf(
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_DHE_PSK_WITH_AES_256_CCM",
+        "TLS_RSA_WITH_3DES_EDE_CBC_Sha"
+    )
+
+    @Mock
+    private val mockDefaultSslSocketFactory = mock<SSLSocketFactory>()
+
+    @Test
+    fun `noWeakCipherSSLSocketFactory() returns unique instance of ssl socket factory`() {
+        val instance1: SSLSocketFactory =
+            NoWeakCipherSSLSocketFactory.noWeakCipherSSLSocketFactory()
+        val instance2: SSLSocketFactory =
+            NoWeakCipherSSLSocketFactory.noWeakCipherSSLSocketFactory()
+
+        assertTrue(instance1 is NoWeakCipherSSLSocketFactory)
+        assertTrue(instance2 is NoWeakCipherSSLSocketFactory)
+        assertEquals(instance1, instance2)
+    }
+
+    @Test
+    fun `createSocket() overload 1 delegates call to default ssl socket factory`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        val socket = mock<Socket>()
+        val host = "some host"
+        val port = 1234
+        val autoClose = true
+
+        val expectedSocket = mock<SSLSocket>()
+        given(mockDefaultSslSocketFactory.createSocket(socket, host, port, autoClose)).willReturn(
+            expectedSocket
+        )
+
+        val result = noWeakCipherSSLSocketFactory.createSocket(socket, host, port, autoClose)
+
+        assertEquals(expectedSocket, result)
+    }
+
+    @Test
+    fun `createSocket() overload 2 delegates call to default ssl socket factory`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        val host = "some host"
+        val port = 1234
+
+        val expectedSocket = mock<SSLSocket>()
+        given(mockDefaultSslSocketFactory.createSocket(host, port)).willReturn(
+            expectedSocket
+        )
+
+        val result = noWeakCipherSSLSocketFactory.createSocket(host, port)
+
+        assertEquals(expectedSocket, result)
+    }
+
+    @Test
+    fun `createSocket() overload 3 delegates call to default ssl socket factory`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        val host = "some host"
+        val port = 1234
+        val localHost = mock<InetAddress>()
+        val localPort = 5678
+
+        val expectedSocket = mock<SSLSocket>()
+        given(
+            mockDefaultSslSocketFactory.createSocket(
+                host,
+                port,
+                localHost,
+                localPort
+            )
+        ).willReturn(
+            expectedSocket
+        )
+
+        val result = noWeakCipherSSLSocketFactory.createSocket(host, port, localHost, localPort)
+
+        assertEquals(expectedSocket, result)
+    }
+
+    @Test
+    fun `createSocket() overload 4 delegates call to default ssl socket factory`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        val host = mock<InetAddress>()
+        val port = 1234
+
+        val expectedSocket = mock<SSLSocket>()
+        given(mockDefaultSslSocketFactory.createSocket(host, port)).willReturn(
+            expectedSocket
+        )
+
+        val result = noWeakCipherSSLSocketFactory.createSocket(host, port)
+
+        assertEquals(expectedSocket, result)
+    }
+
+    @Test
+    fun `createSocket() overload 5 delegates call to default ssl socket factory`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        val address = mock<InetAddress>()
+        val port = 1234
+        val localAddress = mock<InetAddress>()
+        val localPort = 5678
+
+        val expectedSocket = mock<SSLSocket>()
+        given(
+            mockDefaultSslSocketFactory.createSocket(
+                address,
+                port,
+                localAddress,
+                localPort
+            )
+        ).willReturn(
+            expectedSocket
+        )
+
+        val result =
+            noWeakCipherSSLSocketFactory.createSocket(address, port, localAddress, localPort)
+
+        assertEquals(expectedSocket, result)
+    }
+
+    @Test
+    fun `defaultCipherSuites() delegates call to default ssl factory and removes SHA1 cipher suites independently of case`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        given(mockDefaultSslSocketFactory.defaultCipherSuites).willReturn(TEST_CIPHER_SUITES)
+
+        val result = noWeakCipherSSLSocketFactory.defaultCipherSuites
+
+        val expectedCipherSuites = arrayOf(
+            "TLS_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_PSK_WITH_AES_256_CCM"
+        )
+        assertEquals(expectedCipherSuites.toList(), result.toList())
+        verify(mockDefaultSslSocketFactory).defaultCipherSuites
+    }
+
+    @Test
+    fun `supportedCipherSuites delegates call to default ssl factory and removes SHA1 cipher suites independently of case`() {
+        val noWeakCipherSSLSocketFactory = createNoWeakCipherSSLSocketFactory()
+        given(mockDefaultSslSocketFactory.supportedCipherSuites).willReturn(TEST_CIPHER_SUITES)
+
+        val result = noWeakCipherSSLSocketFactory.supportedCipherSuites
+
+        val expectedCipherSuites = arrayOf(
+            "TLS_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_PSK_WITH_AES_256_CCM"
+        )
+        assertEquals(expectedCipherSuites.toList(), result.toList())
+    }
+
+    private fun createNoWeakCipherSSLSocketFactory(): NoWeakCipherSSLSocketFactory {
+        given(mockDefaultSslSocketFactory.defaultCipherSuites).willReturn(TEST_CIPHER_SUITES)
+        given(mockDefaultSslSocketFactory.supportedCipherSuites).willReturn(TEST_CIPHER_SUITES)
+
+        return NoWeakCipherSSLSocketFactory(mockDefaultSslSocketFactory)
+    }
+}

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactoryTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactoryTest.kt
@@ -5,7 +5,6 @@ import java.net.Socket
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.mock
@@ -23,18 +22,6 @@ class NoWeakCipherSSLSocketFactoryTest {
 
     @Mock
     private val mockDefaultSslSocketFactory = mock<SSLSocketFactory>()
-
-    @Test
-    fun `noWeakCipherSSLSocketFactory() returns unique instance of ssl socket factory`() {
-        val instance1: SSLSocketFactory =
-            NoWeakCipherSSLSocketFactory.noWeakCipherSSLSocketFactory()
-        val instance2: SSLSocketFactory =
-            NoWeakCipherSSLSocketFactory.noWeakCipherSSLSocketFactory()
-
-        assertTrue(instance1 is NoWeakCipherSSLSocketFactory)
-        assertTrue(instance2 is NoWeakCipherSSLSocketFactory)
-        assertEquals(instance1, instance2)
-    }
 
     @Test
     fun `createSocket() overload 1 delegates call to default ssl socket factory`() {

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/testutil/TrustAllSSLSocketFactory.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/testutil/TrustAllSSLSocketFactory.kt
@@ -7,6 +7,7 @@ import java.net.Socket
 import java.net.UnknownHostException
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
@@ -16,6 +17,8 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     private val sslContext = SSLContext.getInstance("TLS")
 
     companion object {
+        private val DEFAULT_CIPHER_SUITES = getDefaultSSLSocketFactory().defaultCipherSuites
+
         val X509_TRUST_MANAGER = object : X509TrustManager {
             @SuppressLint("TrustAllX509TrustManager")
             override fun checkClientTrusted(xcs: Array<X509Certificate?>?, string: String?) {
@@ -36,11 +39,16 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     }
 
     override fun getDefaultCipherSuites(): Array<String> {
-        return emptyArray()
+        return DEFAULT_CIPHER_SUITES
     }
 
     @Throws(IOException::class, UnknownHostException::class)
-    override fun createSocket(socket: Socket?, host: String?, port: Int, autoClose: Boolean): Socket? {
+    override fun createSocket(
+        socket: Socket?,
+        host: String?,
+        port: Int,
+        autoClose: Boolean
+    ): Socket? {
         return sslContext.socketFactory.createSocket(socket, host, port, autoClose)
     }
 
@@ -53,7 +61,12 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
         return sslContext.socketFactory.createSocket(host, port)
     }
 
-    override fun createSocket(host: String?, port: Int, localHost: InetAddress?, localPort: Int): Socket {
+    override fun createSocket(
+        host: String?,
+        port: Int,
+        localHost: InetAddress?,
+        localPort: Int
+    ): Socket {
         return sslContext.socketFactory.createSocket(host, port, localHost, localPort)
     }
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -20,6 +20,10 @@ import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
 import com.worldpay.access.checkout.R
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
@@ -27,10 +31,6 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class AccessCheckoutEditTextTest {
     private lateinit var accessCheckoutEditText: AccessCheckoutEditText
@@ -552,9 +552,8 @@ class AccessCheckoutEditTextTest {
         accessCheckoutEditText.background = mock()
     }
 
-
     /**
-    Methods tests
+     Methods tests
      */
     @Test
     fun `length() should return EditText length`() {

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ssl/client/TrustAllSSLSocketFactory.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ssl/client/TrustAllSSLSocketFactory.kt
@@ -7,6 +7,7 @@ import java.net.Socket
 import java.net.UnknownHostException
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
@@ -16,6 +17,8 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     private val sslContext = SSLContext.getInstance("TLS")
 
     companion object {
+        private val DEFAULT_CIPHER_SUITES = HttpsURLConnection.getDefaultSSLSocketFactory().defaultCipherSuites
+
         val X509_TRUST_MANAGER = object : X509TrustManager {
             @SuppressLint("TrustAllX509TrustManager")
             override fun checkClientTrusted(xcs: Array<X509Certificate?>?, string: String?) {
@@ -36,7 +39,7 @@ class TrustAllSSLSocketFactory : SSLSocketFactory() {
     }
 
     override fun getDefaultCipherSuites(): Array<String> {
-        return emptyArray()
+        return DEFAULT_CIPHER_SUITES
     }
 
     @Throws(IOException::class, UnknownHostException::class)


### PR DESCRIPTION
## What
- when a client (SDK) talks to a server (Worldpay APIs) over SSL then a SSL handshake happens. During the handshake both the client and server agree upon an encryption method from the cipher suites they have a common to create keys and encrypt information. More precisely, the client presents a list of cipher suites that it supports for encryption (and the server does the same). The Android library we use under the hood contains out of date ciphers that are insecure (SHA1) which causes the SDK to present these ciphers during the SSL handshake
- This PR is exclude all SHA1 cipher suites from the list presented by the client (SDK) to the server

## How
- a custom SSLSocketFactory has been created to customise the creation of SSL Sockets. Upton creation of a socket, the socket enabledCipherSuites is set to a list that excludes SHA1 ciphers. This list is generated using the default SSL socket factory available on the system
- the HttpsClient uses the SSLSocketFactory. A single instance of SSLSocketFactory is used to avoid a negative impact on performances

## Why
- Without this change, and if the Worldpay APIs used weak ciphers (which they don't), then the client and server could both agree a SHA1 encryption algorithm, leaving the information that transits over TLS vulnerable due to the weakness of the SHA1 algorithm