### PR TITLE
US1806536: fix issue where backspace deletes 2 digits in React Native when deleting a space

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -74,6 +74,7 @@ internal class PanTextWatcher(
         if (isSpaceDeleted) {
             panText = StringBuilder(panText).deleteCharAt(expectedCursorPosition).toString()
             setText(panText, expectedCursorPosition)
+            isSpaceDeleted = false
         }
 
         val brand = findBrandForPan(panText)


### PR DESCRIPTION
## What
- fix issue where backspace deletes 2 digits in React Native when deleting a space. This issue due to a change in the lifecycle of the ReactNativeEditText which was not catered for in the Android SDK
- This issue does not affect Android apps but only React Native apps running in Android

## How
- the ReactNativeEditText calls twice in a row the afterTextChanged() method of the PanTextWatcher(). The code has been changed in the PanTextWatcher so that the portion of code that handles spaces deletion is only ever called once

## Why
- this is a defect which affects end user experience in React Native