### PR TITLE
US1827883: deprecate use of AccessCheckoutClientBuilder.merchantId() in favour of AccessCheckoutClientBuilder.checkoutId()

### DIFF
--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/AccessCheckoutClientIntegrationTest.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/AccessCheckoutClientIntegrationTest.kt
@@ -36,7 +36,7 @@ import org.mockito.Mockito.mock
 class AccessCheckoutClientIntegrationTest {
 
     private val cardSessionEndpoint = "sessions/card"
-    private val merchantId = "identity"
+    private val checkoutId = "identity"
 
     private val applicationContext: Context = getInstrumentation().context.applicationContext
 
@@ -121,7 +121,7 @@ class AccessCheckoutClientIntegrationTest {
         getInstrumentation().runOnMainSync {
             val accessCheckoutClient = AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl().toString())
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(responseListener)
                 .context(applicationContext)
                 .lifecycleOwner(lifecycleOwner)
@@ -171,7 +171,7 @@ class AccessCheckoutClientIntegrationTest {
         getInstrumentation().runOnMainSync {
             val accessCheckoutClient = AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl().toString())
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(responseListener)
                 .context(applicationContext)
                 .lifecycleOwner(lifecycleOwner)
@@ -217,7 +217,7 @@ class AccessCheckoutClientIntegrationTest {
         getInstrumentation().runOnMainSync {
             val accessCheckoutClient = AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl().toString())
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(errorListener)
                 .context(applicationContext)
                 .lifecycleOwner(lifecycleOwner)
@@ -274,7 +274,7 @@ class AccessCheckoutClientIntegrationTest {
         getInstrumentation().runOnMainSync {
             val accessCheckoutClient = AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl().toString())
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(errorListener)
                 .context(applicationContext)
                 .lifecycleOwner(lifecycleOwner)
@@ -313,7 +313,7 @@ class AccessCheckoutClientIntegrationTest {
         getInstrumentation().runOnMainSync {
             val accessCheckoutClient = AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl().toString())
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(errorListener)
                 .context(applicationContext)
                 .lifecycleOwner(lifecycleOwner)
@@ -348,7 +348,7 @@ class AccessCheckoutClientIntegrationTest {
                     "year": ${cardDetails.expiryDate?.year}
                 },
                 "cvc": "${cardDetails.cvc}",
-                "identity": "$merchantId"
+                "identity": "$checkoutId"
             }"""
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilder.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilder.kt
@@ -21,7 +21,7 @@ import java.net.URL
 class AccessCheckoutClientBuilder {
 
     private var baseUrl: String? = null
-    private var merchantId: String? = null
+    private var checkoutId: String? = null
     private var context: Context? = null
     private var externalSessionResponseListener: SessionResponseListener? = null
     private var lifecycleOwner: LifecycleOwner? = null
@@ -37,12 +37,27 @@ class AccessCheckoutClientBuilder {
     }
 
     /**
-     * Sets the merchant id of the client
+     * (Deprecated) Sets the merchant id of the client
      *
      * @param[merchantId] [String] that represents the id of the merchant given to the client at time of registration
      */
+    @Deprecated(
+        message = "Your checkoutId should now be passed to the builder using checkoutId(). The support for passing " +
+            "your checkoutId using merchantId() will be removed in the next major version",
+        replaceWith = ReplaceWith("checkoutId(checkoutId: String)")
+    )
     fun merchantId(merchantId: String): AccessCheckoutClientBuilder {
-        this.merchantId = merchantId
+        this.checkoutId = merchantId
+        return this
+    }
+
+    /**
+     * Sets the checkout id of the client
+     *
+     * @param[checkoutId] [String] that represents the checkoutId given to the merchant at time of registration
+     */
+    fun checkoutId(checkoutId: String): AccessCheckoutClientBuilder {
+        this.checkoutId = checkoutId
         return this
     }
 
@@ -88,14 +103,14 @@ class AccessCheckoutClientBuilder {
      */
     fun build(): AccessCheckoutClient {
         validateNotNull(baseUrl, "base url")
-        validateNotNull(merchantId, "merchant id")
+        validateNotNull(checkoutId, "checkout id")
         validateNotNull(context, "context")
         validateNotNull(externalSessionResponseListener, "session response listener")
         validateNotNull(lifecycleOwner, "lifecycle owner")
 
         val tokenRequestHandlerConfig = SessionRequestHandlerConfig.Builder()
             .baseUrl(URL(baseUrl!!))
-            .merchantId(merchantId!!)
+            .checkoutId(checkoutId!!)
             .context(context!!)
             .externalSessionResponseListener(externalSessionResponseListener!!)
             .build()

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandler.kt
@@ -52,7 +52,7 @@ internal class CardSessionRequestHandler(
             cardDetails.pan!!,
             cardExpiryDate,
             cardDetails.cvc!!,
-            sessionRequestHandlerConfig.getMerchantId()
+            sessionRequestHandlerConfig.getCheckoutId()
         )
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandler.kt
@@ -39,7 +39,7 @@ internal class CvcSessionRequestHandler(
         val cvcSessionRequest =
             CvcSessionRequest(
                 cardDetails.cvc!!,
-                sessionRequestHandlerConfig.getMerchantId()
+                sessionRequestHandlerConfig.getCheckoutId()
             )
 
         val serviceIntent = Intent(sessionRequestHandlerConfig.getContext(), SessionRequestService::class.java)

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfig.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfig.kt
@@ -9,19 +9,19 @@ import java.net.URL
  * This class holds the configuration to be passed to [SessionRequestHandlerFactory] for constructing a [SessionRequestHandler]
  *
  * @property baseUrl [URL] that represents the base url
- * @property merchantId [String] that represents the id of the merchant given to the client at time of registration
+ * @property checkoutId [String] that represents the checkout id of the merchant given to the client at time of registration
  * @property context [Context] that represents the application
  * @property externalSessionResponseListener - An external [SessionResponseListener] that is notified on http requests
  */
 internal class SessionRequestHandlerConfig private constructor(
     private val baseUrl: URL,
-    private val merchantId: String,
+    private val checkoutId: String,
     private val context: Context,
     private val externalSessionResponseListener: SessionResponseListener
 ) {
 
     fun getBaseUrl() = baseUrl
-    fun getMerchantId() = merchantId
+    fun getCheckoutId() = checkoutId
     fun getContext() = context
     fun getExternalSessionResponseListener() = externalSessionResponseListener
 
@@ -30,14 +30,14 @@ internal class SessionRequestHandlerConfig private constructor(
      */
     data class Builder(
         private var baseUrl: URL? = null,
-        private var merchantId: String? = null,
+        private var checkoutId: String? = null,
         private var context: Context? = null,
         private var externalSessionResponseListener: SessionResponseListener? = null
     ) {
 
         fun baseUrl(baseUrl: URL) = apply { this.baseUrl = baseUrl }
 
-        fun merchantId(merchantId: String) = apply { this.merchantId = merchantId }
+        fun checkoutId(checkoutId: String) = apply { this.checkoutId = checkoutId }
 
         fun context(context: Context) = apply { this.context = context }
 
@@ -48,13 +48,13 @@ internal class SessionRequestHandlerConfig private constructor(
 
         fun build(): SessionRequestHandlerConfig {
             validateNotNull(baseUrl, "base url")
-            validateNotNull(merchantId, "merchant id")
+            validateNotNull(checkoutId, "merchant id")
             validateNotNull(context, "context")
             validateNotNull(externalSessionResponseListener, "session response listener")
 
             return SessionRequestHandlerConfig(
                 baseUrl = baseUrl!!,
-                merchantId = merchantId!!,
+                checkoutId = checkoutId!!,
                 context = context!!,
                 externalSessionResponseListener = externalSessionResponseListener!!
             )

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilderTest.kt
@@ -18,7 +18,7 @@ class AccessCheckoutClientBuilderTest {
     private val context = mock(Context::class.java)
     private val sessionResponseListener = mock(SessionResponseListener::class.java)
     private val lifecycleOwner = mock(LifecycleOwner::class.java)
-    private val merchantId = "merchant-123"
+    private val checkoutId = "checkout-id-123"
     private val baseUrl = "https://localhost:8443"
 
     @Before
@@ -27,12 +27,27 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should successfully initialise access checkout client using a builder`() {
+    fun `should successfully initialise access checkout client using a builder and merchantId()`() {
         given(context.applicationContext).willReturn(context)
 
         val accessCheckoutClient = AccessCheckoutClientBuilder()
             .baseUrl(baseUrl)
-            .merchantId(merchantId)
+            .merchantId(checkoutId)
+            .context(context)
+            .sessionResponseListener(sessionResponseListener)
+            .lifecycleOwner(lifecycleOwner)
+            .build()
+
+        assertNotNull(accessCheckoutClient)
+    }
+
+    @Test
+    fun `should successfully initialise access checkout client using a builder and checkoutId()`() {
+        given(context.applicationContext).willReturn(context)
+
+        val accessCheckoutClient = AccessCheckoutClientBuilder()
+            .baseUrl(baseUrl)
+            .checkoutId(checkoutId)
             .context(context)
             .sessionResponseListener(sessionResponseListener)
             .lifecycleOwner(lifecycleOwner)
@@ -62,7 +77,7 @@ class AccessCheckoutClientBuilderTest {
     fun `should throw an illegal argument exception when no baseUrl is passed to builder`() {
         val exception = assertFailsWith<IllegalArgumentException> {
             AccessCheckoutClientBuilder()
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .context(context)
                 .sessionResponseListener(sessionResponseListener)
                 .lifecycleOwner(lifecycleOwner)
@@ -72,7 +87,7 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no merchantId is passed to builder`() {
+    fun `should throw an illegal argument exception when no checkout ID is passed to builder`() {
         val exception = assertFailsWith<IllegalArgumentException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
@@ -81,7 +96,7 @@ class AccessCheckoutClientBuilderTest {
                 .lifecycleOwner(lifecycleOwner)
                 .build()
         }
-        assertEquals("Expected merchant id to be provided but was not", exception.message)
+        assertEquals("Expected checkout id to be provided but was not", exception.message)
     }
 
     @Test
@@ -89,7 +104,7 @@ class AccessCheckoutClientBuilderTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .sessionResponseListener(sessionResponseListener)
                 .lifecycleOwner(lifecycleOwner)
                 .build()
@@ -102,7 +117,7 @@ class AccessCheckoutClientBuilderTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .context(context)
                 .lifecycleOwner(lifecycleOwner)
                 .build()
@@ -118,7 +133,7 @@ class AccessCheckoutClientBuilderTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
-                .merchantId(merchantId)
+                .checkoutId(checkoutId)
                 .context(context)
                 .sessionResponseListener(sessionResponseListener)
                 .build()

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/SessionRequestServiceTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/SessionRequestServiceTest.kt
@@ -205,7 +205,7 @@ class SessionRequestServiceTest {
                     21
                 ),
                 cvc = "123",
-                identity = "merchant-id"
+                identity = "checkout-id"
             )
 
         return SessionRequestInfo.Builder()

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandlerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandlerTest.kt
@@ -40,7 +40,7 @@ class CardSessionRequestHandlerTest {
             CardSessionRequestHandler(
                 SessionRequestHandlerConfig.Builder()
                     .baseUrl(baseUrl)
-                    .merchantId("merchant-id")
+                    .checkoutId("checkout-id")
                     .context(context)
                     .externalSessionResponseListener(externalSessionResponseListener)
                     .build()
@@ -130,7 +130,7 @@ class CardSessionRequestHandlerTest {
         sessionRequestInfo.requestBody as CardSessionRequest
 
         assertEquals(cardDetails.pan, sessionRequestInfo.requestBody.cardNumber)
-        assertEquals("merchant-id", sessionRequestInfo.requestBody.identity)
+        assertEquals("checkout-id", sessionRequestInfo.requestBody.identity)
         assertEquals(cardDetails.cvc, sessionRequestInfo.requestBody.cvc)
         assertEquals(cardDetails.expiryDate?.month, sessionRequestInfo.requestBody.cardExpiryDate.month)
         assertEquals(cardDetails.expiryDate?.year, sessionRequestInfo.requestBody.cardExpiryDate.year)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandlerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandlerTest.kt
@@ -40,7 +40,7 @@ class CvcSessionRequestHandlerTest {
             CvcSessionRequestHandler(
                 SessionRequestHandlerConfig.Builder()
                     .baseUrl(baseUrl)
-                    .merchantId("merchant-id")
+                    .checkoutId("checkout-id")
                     .context(context)
                     .externalSessionResponseListener(externalSessionResponseListener)
                     .build()
@@ -110,7 +110,7 @@ class CvcSessionRequestHandlerTest {
 
         sessionRequestInfo.requestBody as CvcSessionRequest
 
-        assertEquals("merchant-id", sessionRequestInfo.requestBody.identity)
+        assertEquals("checkout-id", sessionRequestInfo.requestBody.identity)
         assertEquals(cardDetails.cvc, sessionRequestInfo.requestBody.cvc)
 
         assertEquals(baseUrl, sessionRequestInfo.baseUrl)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfigTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfigTest.kt
@@ -14,19 +14,19 @@ class SessionRequestHandlerConfigTest {
     @Test
     fun `should be able to create instance of token config and persist the properties`() {
         val baseUrl = URL("http://base-url.com")
-        val merchantId = "merchant-id"
+        val checkoutId = "checkout-id"
         val context = mock(Context::class.java)
         val externalSessionResponseListener = mock(SessionResponseListener::class.java)
 
         val tokenRequestHandlerConfig = SessionRequestHandlerConfig.Builder()
             .baseUrl(baseUrl)
-            .merchantId(merchantId)
+            .checkoutId(checkoutId)
             .context(context)
             .externalSessionResponseListener(externalSessionResponseListener)
             .build()
 
         assertEquals(baseUrl, tokenRequestHandlerConfig.getBaseUrl())
-        assertEquals(merchantId, tokenRequestHandlerConfig.getMerchantId())
+        assertEquals(checkoutId, tokenRequestHandlerConfig.getCheckoutId())
         assertEquals(context, tokenRequestHandlerConfig.getContext())
         assertEquals(
             externalSessionResponseListener,
@@ -38,7 +38,7 @@ class SessionRequestHandlerConfigTest {
     fun `should throw an illegal argument exception when no baseUrl is passed to builder`() {
         val exception = assertFailsWith<IllegalArgumentException> {
             SessionRequestHandlerConfig.Builder()
-                .merchantId("merchant-id")
+                .checkoutId("checkout-id")
                 .context(mock(Context::class.java))
                 .externalSessionResponseListener(mock(SessionResponseListener::class.java))
                 .build()
@@ -47,7 +47,7 @@ class SessionRequestHandlerConfigTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no merchantId is passed to builder`() {
+    fun `should throw an illegal argument exception when no checkoutId is passed to builder`() {
         val exception = assertFailsWith<IllegalArgumentException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
@@ -63,7 +63,7 @@ class SessionRequestHandlerConfigTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
-                .merchantId("merchant-id")
+                .checkoutId("checkout-id")
                 .externalSessionResponseListener(mock(SessionResponseListener::class.java))
                 .build()
         }
@@ -75,7 +75,7 @@ class SessionRequestHandlerConfigTest {
         val exception = assertFailsWith<IllegalArgumentException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
-                .merchantId("merchant-id")
+                .checkoutId("checkout-id")
                 .context(mock(Context::class.java))
                 .build()
         }
@@ -87,7 +87,7 @@ class SessionRequestHandlerConfigTest {
         val exception = assertFailsWith<MalformedURLException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("malformed-url"))
-                .merchantId("merchant-id")
+                .checkoutId("checkout-id")
                 .externalSessionResponseListener(mock(SessionResponseListener::class.java))
                 .context(mock(Context::class.java))
                 .build()

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerFactoryTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerFactoryTest.kt
@@ -14,7 +14,7 @@ class SessionRequestHandlerFactoryTest {
     fun `should return expected list of token request handlers`() {
         val config = SessionRequestHandlerConfig.Builder()
             .baseUrl(URL("http://base-url.com"))
-            .merchantId("merchant-id")
+            .checkoutId("checkout-id")
             .context(Mockito.mock(Context::class.java))
             .externalSessionResponseListener(Mockito.mock(SessionResponseListener::class.java))
             .build()

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -20,6 +20,10 @@ import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
 import com.worldpay.access.checkout.R
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
@@ -28,10 +32,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class AccessCheckoutEditTextTest {
     private lateinit var accessCheckoutEditText: AccessCheckoutEditText

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -183,7 +183,7 @@ workflows:
         inputs:
           - module: "$APP_MODULE"
           - variant: "$APP_PROD_VARIANT"
-          - arguments: -PmerchantID=\"${MERCHANT_ID}\"
+          - arguments: -PcheckoutId=\"${MERCHANT_ID}\"
     - virtual-device-testing-for-android@1.1.8:
         title: "Run integration tests against app"
         inputs:

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 
     applicationVariants.all { variant ->
-        variant.buildConfigField "String", "MERCHANT_ID", merchantID
+        variant.buildConfigField "String", "CHECKOUT_ID", checkoutId
     }
 
     testOptions {

--- a/demo-app/gradle.properties
+++ b/demo-app/gradle.properties
@@ -1,1 +1,1 @@
-merchantID="YOUR_MERCHANT_ID"
+checkoutId="YOUR_CHECKOUT_ID"

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/MainActivityJavaExample.java
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/MainActivityJavaExample.java
@@ -116,8 +116,8 @@ public class MainActivityJavaExample extends AppCompatActivity implements Sessio
         return getString(R.string.endpoint);
     }
 
-    private String getMerchantID() {
-        return BuildConfig.MERCHANT_ID;
+    private String getCheckoutId() {
+        return BuildConfig.CHECKOUT_ID;
     }
 
     private void initialiseValidation() {
@@ -137,7 +137,7 @@ public class MainActivityJavaExample extends AppCompatActivity implements Sessio
     private void initialisePaymentFlow() {
         final AccessCheckoutClient accessCheckoutClient = new AccessCheckoutClientBuilder()
                 .baseUrl(getBaseUrl())
-                .merchantId(getMerchantID())
+                .checkoutId(getCheckoutId())
                 .sessionResponseListener(this)
                 .context(getApplicationContext())
                 .lifecycleOwner(this)

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
@@ -96,7 +96,7 @@ class CardFlowFragment : Fragment() {
     private fun initialisePaymentFlow(activity: FragmentActivity, view: View) {
         val accessCheckoutClient = AccessCheckoutClientBuilder()
             .baseUrl(getBaseUrl())
-            .merchantId(getMerchantID())
+            .checkoutId(getCheckoutId())
             .sessionResponseListener(SessionResponseListenerImpl(activity, progressBar))
             .context(activity.applicationContext)
             .lifecycleOwner(this)
@@ -139,7 +139,7 @@ class CardFlowFragment : Fragment() {
         paymentsCvcSwitch.isEnabled = false
     }
 
-    private fun getMerchantID() = BuildConfig.MERCHANT_ID
+    private fun getCheckoutId() = BuildConfig.CHECKOUT_ID
 
     private fun getBaseUrl() = getString(R.string.endpoint)
 }

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CvcFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CvcFlowFragment.kt
@@ -63,7 +63,7 @@ class CvcFlowFragment : Fragment() {
     private fun initialisePaymentFlow(activity: FragmentActivity, view: View) {
         val accessCheckoutClient = AccessCheckoutClientBuilder()
             .baseUrl(getBaseUrl())
-            .merchantId(getMerchantID())
+            .checkoutId(getCheckoutId())
             .sessionResponseListener(SessionResponseListenerImpl(activity, progressBar))
             .context(activity.applicationContext)
             .lifecycleOwner(this)
@@ -94,7 +94,7 @@ class CvcFlowFragment : Fragment() {
         cvcText.isEnabled = false
     }
 
-    private fun getMerchantID() = BuildConfig.MERCHANT_ID
+    private fun getCheckoutId() = BuildConfig.CHECKOUT_ID
 
     private fun getBaseUrl() = getString(R.string.endpoint)
 }

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/RestrictedCardFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/RestrictedCardFlowFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import com.worldpay.access.checkout.client.validation.AccessCheckoutValidationInitialiser
 import com.worldpay.access.checkout.client.validation.config.CardValidationConfig
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
-import com.worldpay.access.checkout.sample.BuildConfig
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.sample.card.RestrictedCardValidationListener
 import com.worldpay.access.checkout.sample.images.SVGImageLoader
@@ -73,8 +72,6 @@ class RestrictedCardFlowFragment : Fragment() {
 
         AccessCheckoutValidationInitialiser.initialise(cardValidationConfig)
     }
-
-    private fun getMerchantID() = BuildConfig.MERCHANT_ID
 
     private fun getBaseUrl() = getString(R.string.endpoint)
 }


### PR DESCRIPTION
## What
- add method in `AccessCheckoutClientBuilder` to initialise checkoutId using a `checkoutId()` method
- deprecate use of `merchantId()` in AccessCheckoutClientBuilder

## How
- a `checkoutId()` method has been added to `AccessCheckoutClientBuilder`
- the `merchantId()` method in `AccessCheckoutClientBuilder` is still supported but deprecated. Everywhere else `merchantId` has been renamed `checkoutId`. This is a **non-breaking change** because the renaming has been done to only classes that are internal to the SDK
- SwiftDocs has been updated on the `AccessCheckoutClientBuilder` class to reflect this change

## Why
- some merchants have been confused in the past not knowing which id to pass to the SDK because they are provided with both a checkoutId and an identity (backend APIs username). This change is to make clear which ID they must pass. Also it's worth mentioning that `checkoutId` is the name used in our Domain model