### PR TITLE
NOTICKET: change demo app to point to try.access.worldpay.com + improve demo app build stability

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/configuration/CardConfigurationProvider.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/configuration/CardConfigurationProvider.kt
@@ -34,7 +34,7 @@ internal class CardConfigurationProvider(
             } catch (ex: Exception) {
                 Log.d(
                     javaClass.simpleName,
-                    "Error while fetching card configuration (setting defaults): $ex"
+                    "Error while fetching card configuration (setting defaults): $ex", ex
                 )
                 cardConfiguration = CardConfiguration(emptyList(), DefaultCardRules.CARD_DEFAULTS)
             }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/response/SessionResponseTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/response/SessionResponseTest.kt
@@ -76,7 +76,7 @@ class SessionResponseTest {
             SessionResponse(
                 SessionResponse.Links(
                     SessionResponse.Links.Endpoints(
-                        "https://npe.access.worldpay.com/sessions/<encrypted-data>"
+                        "https://try.access.worldpay.com/sessions/<encrypted-data>"
                     ),
                     arrayOf(
                         SessionResponse.Links.Curies(
@@ -133,7 +133,7 @@ class SessionResponseTest {
                     ),
                     arrayOf(
                         SessionResponse.Links.Curies(
-                            "https://npe.access.worldpay.com/rels/sessions{rel}.json",
+                            "https://try.access.worldpay.com/rels/sessions{rel}.json",
                             "sessions",
                             true
                         )
@@ -275,11 +275,11 @@ class SessionResponseTest {
             SessionResponse(
                 SessionResponse.Links(
                     SessionResponse.Links.Endpoints(
-                        "https://npe.access.worldpay.com/sessions/<encrypted-data>"
+                        "https://try.access.worldpay.com/sessions/<encrypted-data>"
                     ),
                     arrayOf(
                         SessionResponse.Links.Curies(
-                            "https://npe.access.worldpay.com/rels/sessions{rel}.json",
+                            "https://try.access.worldpay.com/rels/sessions{rel}.json",
                             "sessions",
                             true
                         )

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -31,6 +31,7 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
     }
 
     fun isInInitialState(): CardFragmentTestUtils {
+        attemptToCloseDialogIfPresent()
         progressBarNotVisible()
         enabledStateIs(pan = true, cvc = true, expiryDate = true, submitButton = false)
         cardDetailsAre(pan = "", cvc = "", expiryDate = "")
@@ -66,6 +67,16 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
 
     fun hasErrorDialogWithMessage(error: String): CardFragmentTestUtils {
         dialogHasText(error)
+        return this
+    }
+
+    fun attemptToCloseDialogIfPresent(): CardFragmentTestUtils {
+        try {
+            onView(withId(android.R.id.button1))
+                .perform(click())
+        } catch (e:Exception) {
+            // no dialog is present
+        }
         return this
     }
 

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.sample.card
 
+import android.util.Log
 import android.widget.ImageView
 import androidx.core.content.res.ResourcesCompat.getColor
 import androidx.fragment.app.FragmentActivity
@@ -30,7 +31,11 @@ class CardValidationListener(private val activity: FragmentActivity) : AccessChe
 
     override fun onBrandChange(cardBrand: CardBrand?) {
         val brandLogo = activity.findViewById<ImageView>(R.id.card_flow_brand_logo)
-        getInstance(activity).fetchAndApplyCardLogo(cardBrand, brandLogo)
+        if (brandLogo != null) {
+            getInstance(activity).fetchAndApplyCardLogo(cardBrand, brandLogo)
+        } else {
+            Log.d(this::class.java.simpleName, "Received CardBranch change but could not find ImageView with id `R.id.card_flow_brand_logo`")
+        }
     }
 
     override fun onExpiryDateValidated(isValid: Boolean) {

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/images/SVGImageLoader.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/images/SVGImageLoader.kt
@@ -106,6 +106,7 @@ class SVGImageLoader @JvmOverloads constructor(
             override fun onResponse(call: Call, response: Response) {
                 response.body?.let { responseBody ->
                     run {
+                        Log.d("SVGImageLoader", "Received image for brand $brandName")
                         svgImageRenderer.renderImage(responseBody.byteStream(), target, brandName)
                     }
                 }

--- a/demo-app/src/prod/res/values/api_config.xml
+++ b/demo-app/src/prod/res/values/api_config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="endpoint">https://npe.access.worldpay.com</string>
+    <string name="endpoint">https://try.access.worldpay.com</string>
 </resources>

--- a/demo-app/src/test/java/com/worldpay/access/checkout/sample/CardConfigurationSchemaTest.kt
+++ b/demo-app/src/test/java/com/worldpay/access/checkout/sample/CardConfigurationSchemaTest.kt
@@ -10,7 +10,7 @@ class CardConfigurationSchemaTest {
 
     @Test
     fun `given local card configuration file in repo then should be valid against remote card configuration JSON schema`() {
-        val url = "https://npe.access.worldpay.com/access-checkout/cardConfigurationSchema.json"
+        val url = "https://try.access.worldpay.com/access-checkout/cardConfigurationSchema.json"
 
         val schema = JsonLoader.fromURL(URL(url))
         val cardConfiguration = JsonLoader.fromPath("src/mock/res/raw/card_configuration_file.json")
@@ -25,7 +25,7 @@ class CardConfigurationSchemaTest {
 
     @Test
     fun `card type file in repo should be valid against remote card configuration JSON schema`() {
-        val url = "https://npe.access.worldpay.com/access-checkout/cardTypesSchema.json"
+        val url = "https://try.access.worldpay.com/access-checkout/cardTypesSchema.json"
 
         val schema = JsonLoader.fromURL(URL(url))
         val cardConfiguration = JsonLoader.fromPath("src/mock/res/raw/card_types.json")


### PR DESCRIPTION
## What
- change demo app to point to try.access.worldpay.com
- add additional logging to improve debugging
- add a null check in demo app to address a race condition where retrieving the card brand configuration may trigger a card logo update whereas the brand logo component is not ready yet in the app