### PR TITLE
Upgrade to support Android 15/API 35

### DIFF
--- a/access-checkout/build.gradle
+++ b/access-checkout/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2'
 
     // override the version of bcprov-jdk15on to avoid the ssl internal errors
-    testImplementation('org.robolectric:robolectric:4.4')
+    testImplementation('org.robolectric:robolectric:4.6')
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
     testImplementation 'au.com.dius:pact-jvm-consumer-junit:4.0.10'

--- a/access-checkout/build.gradle
+++ b/access-checkout/build.gradle
@@ -38,13 +38,14 @@ dependencies {
     androidTestImplementation 'com.google.android.gms:play-services-vision:20.1.3'
     androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2'
 
+    testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.awaitility:awaitility-kotlin:3.1.6'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2'
 
     // override the version of bcprov-jdk15on to avoid the ssl internal errors
-    testImplementation('org.robolectric:robolectric:4.6')
+    testImplementation('org.robolectric:robolectric:4.7')
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
     testImplementation 'au.com.dius:pact-jvm-consumer-junit:4.0.10'

--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -1,5 +1,11 @@
 android {
-    compileSdkVersion 34
+    compileSdk 35
+
+    namespace = "com.worldpay.access.checkout"
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     packagingOptions {
         exclude "**/attach_hotspot_windows.dll"
@@ -19,7 +25,7 @@ android {
 
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -28,7 +34,6 @@ android {
     buildTypes {
         release {
             debuggable false
-            zipAlignEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
@@ -49,7 +54,7 @@ android {
         }
     }
 
-    libraryVariants.all { variant ->
+    libraryVariants.configureEach { variant ->
         variant.outputs.all { output ->
             if (variant.name == "release" && outputFile != null && outputFileName.endsWith('.aar')) {
                 outputFileName = "${archivesBaseName}-${version}.aar"

--- a/access-checkout/gradle/jacoco.gradle
+++ b/access-checkout/gradle/jacoco.gradle
@@ -24,11 +24,11 @@ def fileFilter = [
 ]
 
 def classDirs = files([
-        fileTree(dir: "${layout.buildDirectory}/intermediates/classes/debug", excludes: fileFilter) +
-        fileTree(dir: "${layout.buildDirectory}/tmp/kotlin-classes/debug", excludes: fileFilter)
+        fileTree(dir: "${layout.buildDirectory.dir('.').get().asFile}/intermediates/classes/debug", excludes: fileFilter) +
+        fileTree(dir: "${layout.buildDirectory.dir('.').get().asFile}/tmp/kotlin-classes/debug", excludes: fileFilter)
 ])
 
-def execData = files("$layout.buildDirectory/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+def execData = files("${layout.buildDirectory.dir('.').get().asFile}/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
 
 def sourceDirs = files(["${project.projectDir}/src/main/java"])
 

--- a/access-checkout/gradle/jacoco.gradle
+++ b/access-checkout/gradle/jacoco.gradle
@@ -37,10 +37,6 @@ tasks.register('jacocoTestReport', JacocoReport) {
     executionData.setFrom(execData)
     classDirectories.setFrom(classDirs)
     sourceDirectories.setFrom(sourceDirs)
-
-//    reports {
-//        html.enabled true
-//    }
 }
 
 tasks.register('jacocoTestCoverageVerification', JacocoCoverageVerification) {

--- a/access-checkout/gradle/jacoco.gradle
+++ b/access-checkout/gradle/jacoco.gradle
@@ -24,25 +24,27 @@ def fileFilter = [
 ]
 
 def classDirs = files([
-        fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter) +
-        fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
+        fileTree(dir: "${layout.buildDirectory}/intermediates/classes/debug", excludes: fileFilter) +
+        fileTree(dir: "${layout.buildDirectory}/tmp/kotlin-classes/debug", excludes: fileFilter)
 ])
 
-def execData = files("$buildDir/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+def execData = files("$layout.buildDirectory/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
 
 def sourceDirs = files(["${project.projectDir}/src/main/java"])
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn['testDebugUnitTest']
     executionData.setFrom(execData)
     classDirectories.setFrom(classDirs)
     sourceDirectories.setFrom(sourceDirs)
 
-    reports {
-        html.enabled true
-    }
+//    reports {
+//        html.enabled true
+//    }
 }
 
-task jacocoTestCoverageVerification(type: JacocoCoverageVerification, dependsOn: 'jacocoTestReport') {
+tasks.register('jacocoTestCoverageVerification', JacocoCoverageVerification) {
+    dependsOn 'jacocoTestReport'
     executionData.setFrom(execData)
     classDirectories.setFrom(classDirs)
     sourceDirectories.setFrom(sourceDirs)

--- a/access-checkout/gradle/upload.gradle
+++ b/access-checkout/gradle/upload.gradle
@@ -20,7 +20,7 @@ dokkaJavadoc.dependsOn(':access-checkout:generateReleaseRFile')
 tasks.register('javadocJar', Jar) {
     dependsOn dokkaJavadoc
     archiveClassifier = "javadoc"
-    from "$layout.buildDirectory/dokka/javadoc"
+    from "${layout.buildDirectory.dir('.').get().asFile}/dokka/javadoc"
     archiveAppendix = "android"
 }
 

--- a/access-checkout/gradle/upload.gradle
+++ b/access-checkout/gradle/upload.gradle
@@ -6,23 +6,24 @@ dokkaJavadoc.configure {
     dokkaSourceSets {
         named("main") {
             noAndroidSdkLink.set(false)
-            outputDirectory.set(buildDir.resolve("javadoc"))
+            outputDirectory.set(layout.buildDirectory.resolve("javadoc"))
             skipEmptyPackages.set(true)
             includeNonPublic.set(false)
         }
     }
 }
 
-task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-    classifier "javadoc"
-    from "$buildDir/dokka/javadoc"
-    appendix "android"
+tasks.register('javadocJar', Jar) {
+    dependsOn dokkaJavadoc
+    archiveClassifier = "javadoc"
+    from "$layout.buildDirectory/dokka/javadoc"
+    archiveAppendix = "android"
 }
 
-task sourcesJar(type: Jar) {
-    classifier "sources"
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier = "sources"
     from android.sourceSets.main.java.srcDirs
-    appendix "android"
+    archiveAppendix = "android"
 }
 
 artifacts {

--- a/access-checkout/gradle/upload.gradle
+++ b/access-checkout/gradle/upload.gradle
@@ -13,6 +13,10 @@ dokkaJavadoc.configure {
     }
 }
 
+// Task dependency is required due to an issue in Dokka
+// see https://github.com/Kotlin/dokka/issues/3153
+dokkaJavadoc.dependsOn(':access-checkout:generateReleaseRFile')
+
 tasks.register('javadocJar', Jar) {
     dependsOn dokkaJavadoc
     archiveClassifier = "javadoc"

--- a/access-checkout/src/androidTest/AndroidManifest.xml
+++ b/access-checkout/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.worldpay.access.checkout">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application android:usesCleartextTraffic="true">
         <uses-library android:name="org.apache.http.legacy" android:required="false" />

--- a/access-checkout/src/main/AndroidManifest.xml
+++ b/access-checkout/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.worldpay.access.checkout">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserTest.kt
@@ -7,6 +7,9 @@ import com.worldpay.access.checkout.client.validation.config.CvcValidationConfig
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCvcValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
+import com.worldpay.access.checkout.validation.filters.CvcLengthFilter
+import com.worldpay.access.checkout.validation.filters.ExpiryDateLengthFilter
+import com.worldpay.access.checkout.validation.filters.PanNumericFilter
 import kotlin.test.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -15,6 +18,7 @@ import org.mockito.BDDMockito.given
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowInstrumentation
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class AccessCheckoutValidationInitialiserTest {
@@ -55,9 +59,12 @@ class AccessCheckoutValidationInitialiserTest {
 
         AccessCheckoutValidationInitialiser.initialise(config)
 
-        assertEquals(1, pan.filters.size)
-        assertEquals(1, expiryDate.filters.size)
-        assertEquals(1, cvc.filters.size)
+        // Versions of Android >= 30 add an additional LengthFilter to limit the input to 5,000 chars
+        // So to be flexible with our testing we just test that the 1st filter is the one
+        // expected to be added by our SDK
+        assertTrue (pan.filters[0] is PanNumericFilter)
+        assertTrue (expiryDate.filters[0] is ExpiryDateLengthFilter)
+        assertTrue (cvc.filters[0] is CvcLengthFilter)
     }
 
     @Test
@@ -73,6 +80,6 @@ class AccessCheckoutValidationInitialiserTest {
 
         AccessCheckoutValidationInitialiser.initialise(config)
 
-        assertEquals(1, cvc.filters.size)
+        assertTrue (cvc.filters[0] is CvcLengthFilter)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -46,5 +46,5 @@ subprojects {
 }
 
 tasks.register('clean', Delete) {
-    delete rootProject.layout.buildDirectory
+    delete rootProject.layout.buildDirectory.dir('.').get().asFile
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.5.2'
 
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.6.21'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.9.20'
         classpath 'org.jacoco:org.jacoco.core:0.8.10'
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:10.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         // When updating the android gradle tools version from 7.0.2, ensure that the jacoco report
         // is still generated. See the ./access-checkout/gradle/android.gradle file for reasons.
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.5.2'
 
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.6.21'
@@ -45,6 +45,6 @@ subprojects {
 
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -89,7 +89,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.github.java-json-tools:json-schema-validator:2.2.10'
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.5.0'

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -3,7 +3,13 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 34
+    compileSdk 35
+
+    namespace = "com.worldpay.access.checkout.sample"
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -17,11 +23,11 @@ android {
     defaultConfig {
         applicationId "com.worldpay.access.checkout.sample"
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    flavorDimensions "environment"
+    flavorDimensions = ["environment"]
     productFlavors {
         mock {
             dimension = "environment"
@@ -33,7 +39,7 @@ android {
         }
     }
 
-    applicationVariants.all { variant ->
+    applicationVariants.configureEach { variant ->
         variant.buildConfigField "String", "CHECKOUT_ID", checkoutId
     }
 

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/CardConfigurationLongDelayIntegrationTest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/CardConfigurationLongDelayIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.worldpay.access.checkout.sample.MainActivity
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.sample.card.standard.testutil.CardBrand.MASTERCARD
 import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils
+import com.worldpay.access.checkout.sample.stub.BrandLogoMockStub.stubLogos
 import com.worldpay.access.checkout.sample.stub.CardConfigurationMockStub.stubCardConfiguration
 import com.worldpay.access.checkout.sample.stub.CardConfigurationMockStub.stubCardConfigurationWithDelay
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -19,10 +20,11 @@ import org.junit.Test
 
 class CardConfigurationLongDelayIntegrationTest {
 
-    private val timeoutInMillis = 10000L
+    private val timeoutInMillis = 20000L
+    private val delayInMillis = 10000L
 
     @get:Rule
-    var cardConfigRule = CardConfigurationLongDelayRule(timeoutInMillis, MainActivity::class.java)
+    var cardConfigRule = CardConfigurationLongDelayRule(delayInMillis, MainActivity::class.java)
 
     private lateinit var cardFragmentTestUtils: CardFragmentTestUtils
 
@@ -90,14 +92,21 @@ class CardConfigurationLongDelayIntegrationTest {
 }
 
 class CardConfigurationLongDelayRule(
-    private val timeoutMillis: Long,
+    private val delayMillis: Long,
     activityClass: Class<MainActivity>
 ) : ActivityTestRule<MainActivity>(activityClass) {
 
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
+
         // This card configuration rule adds stubs to mock server to simulate a long delay condition on the card configuration endpoint.
         // On initialisation of our SDK, the SDK will trigger a card configuration call which will get back this delayed response.
-        stubCardConfigurationWithDelay(timeoutMillis.toInt())
+        stubCardConfigurationWithDelay(delayMillis.toInt())
+    }
+
+    override fun afterActivityLaunched() {
+        super.afterActivityLaunched()
+
+        stubLogos(activity.applicationContext)
     }
 }

--- a/demo-app/src/mock/java/com/worldpay/access/checkout/sample/MockServer.kt
+++ b/demo-app/src/mock/java/com/worldpay/access/checkout/sample/MockServer.kt
@@ -92,17 +92,21 @@ object MockServer {
 
     fun defaultStubMappings(context: Context) {
         Log.d("MockServer", "Stubbing root endpoint with 200 response")
-        wireMockServer.stubFor(rootResourceMapping())
+        try {
+            wireMockServer.stubFor(rootResourceMapping())
+            // sessions service root endpoint
+            stubSessionsTokenRootRequest()
 
-        // sessions service root endpoint
-        stubSessionsTokenRootRequest()
+            // card and cvc sessions endpoints
+            stubSessionsCardRequest(context)
+            stubSessionsPaymentCvcRequest(context)
 
-        // card and cvc sessions endpoints
-        stubSessionsCardRequest(context)
-        stubSessionsPaymentCvcRequest(context)
+            stubCardConfiguration(context)
+            stubLogos(context)
+        } catch (e:Exception) {
+            Log.d("MockServer", "Failed to set up default stub mappings ${e.message}",)
+        }
 
-        stubCardConfiguration(context)
-        stubLogos(context)
     }
 
     private fun waitForWiremock() {

--- a/demo-app/src/test/java/com/worldpay/access/checkout/sample/images/SVGImageLoaderTest.kt
+++ b/demo-app/src/test/java/com/worldpay/access/checkout/sample/images/SVGImageLoaderTest.kt
@@ -3,9 +3,6 @@ package com.worldpay.access.checkout.sample.images
 import android.app.Activity
 import android.content.res.Resources
 import android.widget.ImageView
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.given
 import com.worldpay.access.checkout.client.validation.model.CardBrand
 import com.worldpay.access.checkout.client.validation.model.CardBrandImage
 import com.worldpay.access.checkout.sample.R
@@ -21,14 +18,22 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyZeroInteractions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verifyNoInteractions
 
 class SVGImageLoaderTest {
 
     private val cardBrand =
         CardBrand(
             name = "visa",
-            images = listOf(CardBrandImage(type = "image/svg+xml", url = "https://localhost:8443/test.svg"))
+            images = listOf(
+                CardBrandImage(
+                    type = "image/svg+xml",
+                    url = "https://localhost:8443/test.svg"
+                )
+            )
         )
 
     private lateinit var activity: Activity
@@ -83,7 +88,7 @@ class SVGImageLoaderTest {
 
         svgImageLoader.fetchAndApplyCardLogo(null, targetImageView)
 
-        verifyZeroInteractions(client)
+        verifyNoInteractions(client)
 
         verify(targetImageView).setImageResource(R.drawable.card_unknown_logo)
         verify(targetImageView).setTag(R.integer.card_tag, "card_unknown_logo")
@@ -94,7 +99,12 @@ class SVGImageLoaderTest {
         val cardBrandWithNoSVG =
             CardBrand(
                 name = "visa",
-                images = listOf(CardBrandImage(type = "image/png", url = "https://localhost:8443/test.png"))
+                images = listOf(
+                    CardBrandImage(
+                        type = "image/png",
+                        url = "https://localhost:8443/test.png"
+                    )
+                )
             )
 
         val mockHttpCall = mock(Call::class.java)
@@ -112,7 +122,7 @@ class SVGImageLoaderTest {
 
         svgImageLoader.fetchAndApplyCardLogo(cardBrandWithNoSVG, targetImageView)
 
-        verifyZeroInteractions(client)
+        verifyNoInteractions(client)
         verify(targetImageView).setImageResource(R.drawable.card_unknown_logo)
         verify(targetImageView).setTag(R.integer.card_tag, "card_unknown_logo")
     }
@@ -136,7 +146,7 @@ class SVGImageLoaderTest {
 
         // Trigger onFailure callback function
         captor.firstValue.onFailure(mockHttpCall, IOException("some message"))
-        verifyZeroInteractions(svgImageRenderer)
-        verifyZeroInteractions(targetImageView)
+        verifyNoInteractions(svgImageRenderer)
+        verifyNoInteractions(targetImageView)
     }
 }

--- a/demo-app/src/test/java/com/worldpay/access/checkout/sample/images/SVGImageRendererImplTest.kt
+++ b/demo-app/src/test/java/com/worldpay/access/checkout/sample/images/SVGImageRendererImplTest.kt
@@ -6,8 +6,8 @@ import android.graphics.drawable.PictureDrawable
 import android.view.View
 import android.widget.ImageView
 import com.caverock.androidsvg.SVG
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verifyNoInteractions
 import com.worldpay.access.checkout.sample.R
 import java.io.InputStream
 import org.junit.Before
@@ -64,6 +64,6 @@ class SVGImageRendererImplTest {
 
         svgImageRenderer.renderImage(mockInputStream, target, "someName")
 
-        verifyZeroInteractions(target)
+        verifyNoInteractions(target)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ kotlin.code.style=official
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.nonTransitiveRClass=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip


### PR DESCRIPTION
## What
- migrate to Gradle 8 to support running tests and release SDK for Android 15/35 
- fix issue with Dokka plugin following to Gradle build - see [this link](https://github.com/Kotlin/dokka/issues/3153)
- fix broken UI test
- upgrade version of Robolectric due to upgrade to Gradle 8 using Java 17
  - we're not using the latest version of Robolectric though because it requires a more recent version of Java
- fix unit test broken when running on Android versions 30 and above. These versions add an additional LengthFilter to EditText when setting up the inputType, which was failing one of our unit test. The testing logic in the unit test has been changed to cater for that. FYI The filter is designed to limit the length of text to 5,000 characters max. The filters added by the SDK will take precedence and will correctly trim the pan, expiry date and cvc to the max length allowed, so we're safe despite this small difference of implementation
- broken UI test was failing due to having omitted to stub the service that deals with assets for card brands. As a consequence requests to retrieve card brand images were failing with 404s and the test was failing


## How
- used following guides for upgrading Gradle
  - [https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes)
  - [https://docs.gradle.org/current/userguide/upgrading_version_7.html](https://docs.gradle.org/current/userguide/upgrading_version_7.html)