### PR TITLE
US2132059: Replace IllegalArgument Exceptions with ACE(AccessCheckoutExceptions)

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilder.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilder.kt
@@ -84,7 +84,7 @@ class AccessCheckoutClientBuilder {
      * Builds the [AccessCheckoutClient] instance
      *
      * @return [AccessCheckoutClient] interface with a default internal implementation
-     * @throws [IllegalArgumentException] is thrown when a property is missing
+     * @throws [AccessCheckoutException] is thrown when a property is missing
      */
     fun build(): AccessCheckoutClient {
         validateNotNull(baseUrl, "base url")

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/model/CardDetails.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/session/model/CardDetails.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.client.session.model
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 
 /**
@@ -78,7 +79,7 @@ class CardDetails private constructor(
             val isCorrectLength = expiryDateWithoutSeparator.length == maxExpiryDateLength
 
             if (!isCorrectLength || !isNumeric) {
-                throw IllegalArgumentException("expecting expiry date in format MM/YY or MMYY but found $expiryDate")
+                throw AccessCheckoutException("expecting expiry date in format MM/YY or MMYY but found $expiryDate")
             }
 
             if (expiryDate.contains(separator)) {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfig.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfig.kt
@@ -121,7 +121,7 @@ class CardValidationConfig private constructor(
          * Builds the validation configuration by returning an instance of the [CardValidationConfig]
          *
          * @return [CardValidationConfig] implementation that can be used to initialise validation
-         * @throws [IllegalArgumentException] is thrown when a property is missing
+         * @throws [AccessCheckoutException] is thrown when a property is missing
          */
         fun build(): CardValidationConfig {
             validateNotNull(pan, "pan component")

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfig.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfig.kt
@@ -62,7 +62,7 @@ class CvcValidationConfig private constructor(
          * Builds the validation configuration by returning an instance of the [CvcValidationConfig]
          *
          * @return [CvcValidationConfig] implementation that can be used to initialise validation
-         * @throws [IllegalArgumentException] is thrown when a property is missing
+         * @throws [AccessCheckoutException] is thrown when a property is missing
          */
         fun build(): CvcValidationConfig {
             validateNotNull(cvc, "cvc component")

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/SessionClientFactory.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/client/SessionClientFactory.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.api.client
 
 import com.worldpay.access.checkout.api.HttpsClient
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest
 import com.worldpay.access.checkout.session.api.request.CvcSessionRequest
 import com.worldpay.access.checkout.session.api.request.SessionRequest
@@ -21,7 +22,7 @@ internal class SessionClientFactory {
      * @param[sessionRequest] The session request information
      *
      * @return an implementation of [SessionClient]
-     * @throws [IllegalArgumentException] is thrown when the given [sessionRequest] is not recognised
+     * @throws [AccessCheckoutException] is thrown when the given [sessionRequest] is not recognised
      */
     fun createClient(sessionRequest: SessionRequest): SessionClient {
         when (sessionRequest) {
@@ -40,7 +41,7 @@ internal class SessionClientFactory {
                 )
             }
             else -> {
-                throw IllegalArgumentException("unknown session request type found")
+                throw AccessCheckoutException("unknown session request type found")
             }
         }
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/serialization/CardSessionRequestSerializer.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/serialization/CardSessionRequestSerializer.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.api.serialization
 
 import com.worldpay.access.checkout.api.serialization.Serializer
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest
 import com.worldpay.access.checkout.session.api.request.SessionRequest
 import org.json.JSONObject
@@ -12,7 +13,7 @@ internal class CardSessionRequestSerializer : Serializer<SessionRequest> {
 
     override fun serialize(instance: SessionRequest): String {
         if (instance !is CardSessionRequest) {
-            throw IllegalArgumentException("could not serialize session request")
+            throw AccessCheckoutException("could not serialize session request")
         }
 
         val root = JSONObject()

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/serialization/CvcSessionRequestSerializer.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/session/api/serialization/CvcSessionRequestSerializer.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.api.serialization
 
 import com.worldpay.access.checkout.api.serialization.Serializer
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CvcSessionRequest
 import com.worldpay.access.checkout.session.api.request.SessionRequest
 import org.json.JSONObject
@@ -12,7 +13,7 @@ internal class CvcSessionRequestSerializer : Serializer<SessionRequest> {
 
     override fun serialize(instance: SessionRequest): String {
         if (instance !is CvcSessionRequest) {
-            throw IllegalArgumentException("could not serialize session request")
+            throw AccessCheckoutException("could not serialize session request")
         }
 
         val root = JSONObject()

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/util/PropertyValidationUtil.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/util/PropertyValidationUtil.kt
@@ -1,10 +1,12 @@
 package com.worldpay.access.checkout.util
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
+
 internal object PropertyValidationUtil {
 
     fun validateNotNull(property: Any?, propertyKey: String) {
         if (property == null) {
-            throw IllegalArgumentException("Expected $propertyKey to be provided but was not")
+            throw AccessCheckoutException("Expected $propertyKey to be provided but was not")
         }
     }
 }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/AccessCheckoutClientBuilderTest.kt
@@ -3,6 +3,7 @@ package com.worldpay.access.checkout.client.session
 import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.session.listener.SessionResponseListener
 import java.lang.reflect.Field
 import kotlin.test.assertEquals
@@ -59,8 +60,8 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no baseUrl is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no baseUrl is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             AccessCheckoutClientBuilder()
                 .checkoutId(checkoutId)
                 .context(context)
@@ -72,8 +73,8 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no checkout ID is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no checkout ID is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
                 .context(context)
@@ -85,8 +86,8 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no context is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no context is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
                 .checkoutId(checkoutId)
@@ -98,8 +99,8 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no Session Response Listener is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no Session Response Listener is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
                 .checkoutId(checkoutId)
@@ -114,8 +115,8 @@ class AccessCheckoutClientBuilderTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no lifecycle owner is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no lifecycle owner is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             AccessCheckoutClientBuilder()
                 .baseUrl(baseUrl)
                 .checkoutId(checkoutId)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/model/CardDetailsTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/session/model/CardDetailsTest.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.client.session.model
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.testutils.createAccessCheckoutEditTextMock
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -71,7 +72,7 @@ class CardDetailsTest {
         val expiryDate = createAccessCheckoutEditTextMock("11200")
         val cvc = createAccessCheckoutEditTextMock("123")
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardDetails.Builder()
                 .pan(pan)
                 .expiryDate(expiryDate)
@@ -88,7 +89,7 @@ class CardDetailsTest {
         val expiryDate = createAccessCheckoutEditTextMock("abcd")
         val cvc = createAccessCheckoutEditTextMock("123")
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardDetails.Builder()
                 .pan(pan)
                 .expiryDate(expiryDate)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfigBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfigBuilderTest.kt
@@ -2,6 +2,7 @@ package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
 import androidx.lifecycle.LifecycleOwner
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 import kotlin.test.*
@@ -92,7 +93,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where base url is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .pan(pan)
                 .expiryDate(expiryDate)
@@ -108,7 +109,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where pan is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .baseUrl(baseUrl)
                 .expiryDate(expiryDate)
@@ -124,7 +125,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where expiry date is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .baseUrl(baseUrl)
                 .pan(pan)
@@ -140,7 +141,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where cvc is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .baseUrl(baseUrl)
                 .pan(pan)
@@ -156,7 +157,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where validation listener is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .baseUrl(baseUrl)
                 .pan(pan)
@@ -172,7 +173,7 @@ class CardValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where lifecycle owner is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CardValidationConfig.Builder()
                 .baseUrl(baseUrl)
                 .pan(pan)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfigBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfigBuilderTest.kt
@@ -2,6 +2,7 @@ package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
 import androidx.lifecycle.LifecycleOwner
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCvcValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 import kotlin.test.assertEquals
@@ -40,7 +41,7 @@ class CvcValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where cvc is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CvcValidationConfig.Builder()
                 .validationListener(validationListener)
                 .lifecycleOwner(lifecycleOwner)
@@ -52,7 +53,7 @@ class CvcValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where lifecycle owner is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CvcValidationConfig.Builder()
                 .cvc(cvc)
                 .validationListener(validationListener)
@@ -64,7 +65,7 @@ class CvcValidationConfigBuilderTest {
 
     @Test
     fun `should throw exception where validation listener is not provided`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             CvcValidationConfig.Builder()
                 .cvc(cvc)
                 .lifecycleOwner(lifecycleOwner)

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/SessionClientFactoryTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/client/SessionClientFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.session.api.client
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest
 import com.worldpay.access.checkout.session.api.request.CvcSessionRequest
 import com.worldpay.access.checkout.session.api.request.SessionRequest
@@ -47,7 +48,7 @@ class SessionClientFactoryTest {
 
     @Test
     fun `should throw exception when suitable request is not found`() {
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<AccessCheckoutException> {
             sessionClientFactory.createClient(InvalidSessionRequest())
         }
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/serialization/CardSessionRequestSerializerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/serialization/CardSessionRequestSerializerTest.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.api.serialization
 
 import com.worldpay.access.checkout.api.serialization.Serializer
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest.CardExpiryDate
 import com.worldpay.access.checkout.session.api.request.CvcSessionRequest
@@ -49,7 +50,7 @@ class CardSessionRequestSerializerTest {
                 "123",
                 "MERCHANT-123"
             )
-        assertFailsWith<IllegalArgumentException> { sessionRequestSerializer.serialize(sessionRequest) }
+        assertFailsWith<AccessCheckoutException> { sessionRequestSerializer.serialize(sessionRequest) }
     }
 
     private fun removeWhitespace(string: String): String {

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/serialization/CvcSessionRequestSerializerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/api/serialization/CvcSessionRequestSerializerTest.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.api.serialization
 
 import com.worldpay.access.checkout.api.serialization.Serializer
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest
 import com.worldpay.access.checkout.session.api.request.CardSessionRequest.CardExpiryDate
 import com.worldpay.access.checkout.session.api.request.CvcSessionRequest
@@ -42,7 +43,7 @@ class CvcSessionRequestSerializerTest {
                 identity = "MERCHANT-123"
             )
 
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<AccessCheckoutException> {
             sessionRequestSerializer.serialize(
                 sessionRequest
             )

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/broadcast/receivers/SessionBroadcastReceiverTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/broadcast/receivers/SessionBroadcastReceiverTest.kt
@@ -234,13 +234,13 @@ class SessionBroadcastReceiverTest {
     fun `should notify with custom error when a response that is not a session response and error deserialize failure`() {
         broadcastNumSessionTypesRequested(2)
 
-        val illegalArgumentException = IllegalArgumentException("")
+        val AccessCheckoutException = AccessCheckoutException("")
         val expectedEx =
-            AccessCheckoutException("Unknown error", illegalArgumentException)
+            AccessCheckoutException("Unknown error", AccessCheckoutException)
 
         given(intent.action).willReturn(COMPLETED_SESSION_REQUEST)
         given(intent.getSerializableExtra("response")).willReturn(TestObject("something"))
-        given(intent.getSerializableExtra("error")).willReturn(illegalArgumentException)
+        given(intent.getSerializableExtra("error")).willReturn(AccessCheckoutException)
 
         sessionBroadcastReceiver.onReceive(context, intent)
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandlerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CardSessionRequestHandlerTest.kt
@@ -3,6 +3,7 @@ package com.worldpay.access.checkout.session.handlers
 import android.content.Context
 import android.content.Intent
 import com.worldpay.access.checkout.api.discovery.DiscoverLinks
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.session.listener.SessionResponseListener
 import com.worldpay.access.checkout.client.session.model.CardDetails
 import com.worldpay.access.checkout.client.session.model.SessionType.CARD
@@ -58,7 +59,7 @@ class CardSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should throw illegal argument exception if pan is not provided in card details`() {
+    fun `should throw AccessCheckoutException if pan is not provided in card details`() {
         val expiryDate = createAccessCheckoutEditTextMock("1120")
         val cvc = createAccessCheckoutEditTextMock("123")
 
@@ -67,7 +68,7 @@ class CardSessionRequestHandlerTest {
             .cvc(cvc)
             .build()
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             cardSessionRequestHandler.handle(cardDetails)
         }
 
@@ -75,7 +76,7 @@ class CardSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should throw illegal argument exception if expiry date is not provided in card details`() {
+    fun `should throw AccessCheckoutException if expiry date is not provided in card details`() {
         val pan = createAccessCheckoutEditTextMock("1234")
         val cvc = createAccessCheckoutEditTextMock("123")
 
@@ -84,7 +85,7 @@ class CardSessionRequestHandlerTest {
             .cvc(cvc)
             .build()
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             cardSessionRequestHandler.handle(cardDetails)
         }
 
@@ -92,7 +93,7 @@ class CardSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should throw illegal argument exception if cvc is not provided in card details`() {
+    fun `should throw AccessCheckoutException if cvc is not provided in card details`() {
         val pan = createAccessCheckoutEditTextMock("1234")
         val expiryDate = createAccessCheckoutEditTextMock("1120")
 
@@ -101,7 +102,7 @@ class CardSessionRequestHandlerTest {
             .expiryDate(expiryDate)
             .build()
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             cardSessionRequestHandler.handle(cardDetails)
         }
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandlerTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/CvcSessionRequestHandlerTest.kt
@@ -3,6 +3,7 @@ package com.worldpay.access.checkout.session.handlers
 import android.content.Context
 import android.content.Intent
 import com.worldpay.access.checkout.api.discovery.DiscoverLinks
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.session.listener.SessionResponseListener
 import com.worldpay.access.checkout.client.session.model.CardDetails
 import com.worldpay.access.checkout.client.session.model.SessionType.CARD
@@ -58,7 +59,7 @@ class CvcSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should not throw illegal argument exception if pan is not provided in card details`() {
+    fun `should not throw AccessCheckoutException if pan is not provided in card details`() {
         val expiryDate = createAccessCheckoutEditTextMock("1120")
         val cvc = createAccessCheckoutEditTextMock("123")
 
@@ -70,7 +71,7 @@ class CvcSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should not throw illegal argument exception if expiry date is not provided in card details`() {
+    fun `should not throw AccessCheckoutException if expiry date is not provided in card details`() {
         val pan = createAccessCheckoutEditTextMock("123456789")
         val cvc = createAccessCheckoutEditTextMock("123")
 
@@ -82,10 +83,10 @@ class CvcSessionRequestHandlerTest {
     }
 
     @Test
-    fun `should throw illegal argument exception if cvc is not provided in card details`() {
+    fun `should throw AccessCheckoutException if cvc is not provided in card details`() {
         val cardDetails = CardDetails.Builder().build()
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<AccessCheckoutException> {
             cvcSessionRequestHandler.handle(cardDetails)
         }
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfigTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/SessionRequestHandlerConfigTest.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.session.handlers
 
 import android.content.Context
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.session.listener.SessionResponseListener
 import java.net.MalformedURLException
 import java.net.URL
@@ -35,8 +36,8 @@ class SessionRequestHandlerConfigTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no baseUrl is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no baseUrl is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             SessionRequestHandlerConfig.Builder()
                 .checkoutId("checkout-id")
                 .context(mock(Context::class.java))
@@ -47,8 +48,8 @@ class SessionRequestHandlerConfigTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no checkoutId is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no checkoutId is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
                 .context(mock(Context::class.java))
@@ -59,8 +60,8 @@ class SessionRequestHandlerConfigTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no context is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no context is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
                 .checkoutId("checkout-id")
@@ -71,8 +72,8 @@ class SessionRequestHandlerConfigTest {
     }
 
     @Test
-    fun `should throw an illegal argument exception when no external session response listener is passed to builder`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw an AccessCheckoutException when no external session response listener is passed to builder`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             SessionRequestHandlerConfig.Builder()
                 .baseUrl(URL("http://base-url.com"))
                 .checkoutId("checkout-id")

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/testutils/CardNumberUtil.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/testutils/CardNumberUtil.kt
@@ -1,5 +1,7 @@
 package com.worldpay.access.checkout.testutils
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
+
 object CardNumberUtil {
 
     const val PARTIAL_VISA = "4111"
@@ -23,14 +25,14 @@ object CardNumberUtil {
                 16 -> "4111 1111 1111 1111"
                 18 -> "4111 1111 1111 1111 11"
                 19 -> "4444 3333 2222 1111 000"
-                else -> throw IllegalArgumentException("valid lengths are 16, 18, 19")
+                else -> throw AccessCheckoutException("valid lengths are 16, 18, 19")
             }
         } else {
             when (length) {
                 16 -> "4111111111111111"
                 18 -> "411111111111111111"
                 19 -> "4444333322221111000"
-                else -> throw IllegalArgumentException("valid lengths are 16, 18, 19")
+                else -> throw AccessCheckoutException("valid lengths are 16, 18, 19")
             }
         }
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/util/PropertyValidationUtilTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/util/PropertyValidationUtilTest.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.util
 
+import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.util.PropertyValidationUtil.validateNotNull
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -8,8 +9,8 @@ import org.junit.Test
 class PropertyValidationUtilTest {
 
     @Test
-    fun `should throw illegal argument exception with expected message when property is null`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
+    fun `should throw AccessCheckoutException with expected message when property is null`() {
+        val exception = assertFailsWith<AccessCheckoutException> {
             validateNotNull(null, "property-name")
         }
 
@@ -17,7 +18,7 @@ class PropertyValidationUtilTest {
     }
 
     @Test
-    fun `should not throw illegal argument exception when property is not null`() {
+    fun `should not throw AccessCheckoutException when property is not null`() {
         validateNotNull("some-value", "property-name")
     }
 }

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
@@ -20,13 +20,13 @@ class CardValidationListener(private val activity: FragmentActivity) : AccessChe
     override fun onCvcValidated(isValid: Boolean) {
         val cvc = activity.findViewById<AccessCheckoutEditText>(R.id.card_flow_text_cvc)
         changeFont(cvc, isValid)
-        if (!isValid) submitButton.disable()
+        if (!isValid) submitButton.enable()
     }
 
     override fun onPanValidated(isValid: Boolean) {
         val pan = activity.findViewById<AccessCheckoutEditText>(R.id.card_flow_text_pan)
         changeFont(pan, isValid)
-        if (!isValid) submitButton.disable()
+        if (!isValid) submitButton.enable()
     }
 
     override fun onBrandChange(cardBrand: CardBrand?) {
@@ -41,7 +41,7 @@ class CardValidationListener(private val activity: FragmentActivity) : AccessChe
     override fun onExpiryDateValidated(isValid: Boolean) {
         val expiryText = activity.findViewById<AccessCheckoutEditText>(R.id.card_flow_expiry_date)
         changeFont(expiryText, isValid)
-        if (!isValid) submitButton.disable()
+        if (!isValid) submitButton.enable()
     }
 
     override fun onValidationSuccess() = submitButton.enable()

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
@@ -72,7 +72,7 @@ class CardFlowFragment : Fragment() {
         super.onResume()
         if (progressBar.isLoading()) {
             disableFields()
-            submitBtn.disable()
+            submitBtn.enable()
         } else {
             initialiseCardValidation(cardValidationListener)
         }
@@ -106,7 +106,7 @@ class CardFlowFragment : Fragment() {
             Log.d(javaClass.simpleName, "Started request")
             this.progressBar.beginLoading()
             disableFields()
-            submitBtn.disable()
+            submitBtn.enable()
 
             val cardDetails = CardDetails.Builder()
                 .pan(panText)


### PR DESCRIPTION
### What

Replace IllegalArgument Exceptions with ACE(AccessCheckoutExceptions) so that merchants have a single exception to handle 

### Why

This is so that merchants have a single exception to handle, simplifying the devex and integration experience