### PR TITLE
NOTICKET: enable parallel tests

### DIFF
--- a/access-checkout/build.gradle
+++ b/access-checkout/build.gradle
@@ -52,5 +52,5 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2)
+    maxParallelForks = Runtime.runtime.availableProcessors()
 }

--- a/access-checkout/build.gradle
+++ b/access-checkout/build.gradle
@@ -50,3 +50,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
     testImplementation 'au.com.dius:pact-jvm-consumer-junit:4.0.10'
 }
+
+tasks.withType(Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}

--- a/access-checkout/build.gradle
+++ b/access-checkout/build.gradle
@@ -52,5 +52,5 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2)
 }

--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -36,7 +36,7 @@ android {
             debuggable false
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
         }
         debug {
             // The test coverage has been disabled here due to a bug in the android build tools (7.0.2)
@@ -50,7 +50,7 @@ android {
             testCoverageEnabled = true
             debuggable = true
             minifyEnabled = false
-            buildConfigField("String","VERSION_NAME","\"${defaultConfig.versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
         }
     }
 

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -101,5 +101,5 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2)
 }

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -101,5 +101,5 @@ dependencies {
 }
 
 tasks.withType(Test) {
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2)
+    maxParallelForks = Runtime.runtime.availableProcessors()
 }

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -99,3 +99,7 @@ dependencies {
     androidTestImplementation 'org.awaitility:awaitility-kotlin:3.1.6'
 
 }
+
+tasks.withType(Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}


### PR DESCRIPTION
### What

- Enable parallel gradle tasks 

### Why

This is so that tests can run in parallel taking advantage of cores and reducing tests times