### PR TITLE
US2121248: add logging of scheme when pan is >= 12

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -30,13 +30,13 @@ internal class PanTextWatcher(
     private val cvcValidationRuleManager: CVCValidationRuleManager
 ) : AbstractCardDetailTextWatcher() {
 
-    private var cardBrands: List<RemoteCardBrand?> = emptyList()
+    private var cardBrands: List<RemoteCardBrand> = emptyList()
     private var panBefore = ""
     private var cursorPositionBefore = 0
 
     private var expectedCursorPosition = 0
     private var isSpaceDeleted = false
-    private val requiredPanLengthForScheme = 12
+    private val requiredPanLengthForCardBrands = 12
 
     override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
         super.beforeTextChanged(s, start, count, after)
@@ -212,7 +212,7 @@ internal class PanTextWatcher(
      * This function also revalidates the cvc using the cvc validation
      * rule of the new card brand
      */
-    private fun handleCardBrandChange(newCardBrands: List<RemoteCardBrand?>) {
+    private fun handleCardBrandChange(newCardBrands: List<RemoteCardBrand>) {
         if (cardBrands == newCardBrands) return
 
         cardBrands = newCardBrands
@@ -244,12 +244,18 @@ internal class PanTextWatcher(
         panEditText.setSelection(selection)
     }
 
-    private fun getCardBrands(newCardBrand: RemoteCardBrand?): List<RemoteCardBrand?> {
+    private fun getCardBrands(newCardBrand: RemoteCardBrand?): List<RemoteCardBrand> {
+        if (newCardBrand == null) {
+            return emptyList()
+        }
+
         if (isPanRequiredLength()) {
             val hardCodedBrand = findBrandForPan("5555444433332222")
-            val hardCodedBrands = listOf(newCardBrand, hardCodedBrand)
-            Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
-            return hardCodedBrands
+            if (hardCodedBrand != null) {
+                val hardCodedBrands = listOf(newCardBrand, hardCodedBrand)
+                Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+                return hardCodedBrands
+            }
         }
         return listOf(newCardBrand)
     }
@@ -257,6 +263,6 @@ internal class PanTextWatcher(
     private fun isPanRequiredLength(): Boolean {
         val pan = panEditText.text.toString()
         val formattedPan = pan.replace(" ", "").length
-        return (formattedPan >= requiredPanLengthForScheme)
+        return (formattedPan >= requiredPanLengthForCardBrands)
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -89,6 +89,7 @@ internal class PanTextWatcher(
             return
         }
         handleCardBrandChange(brand)
+        logCardBrands(brand)
         validate(newPan, cardValidationRule, brand)
 
         if (newPan != panText) {
@@ -210,8 +211,6 @@ internal class PanTextWatcher(
      * rule of the new card brand
      */
     private fun handleCardBrandChange(newCardBrand: RemoteCardBrand?) {
-        if (isPanRequiredLength()) logCardBrands(newCardBrand)
-
         if (cardBrand == newCardBrand) return
 
         cardBrand = newCardBrand
@@ -245,9 +244,11 @@ internal class PanTextWatcher(
     }
 
     private fun logCardBrands(newCardBrand: RemoteCardBrand?) {
-        val hardCodedBrand = findBrandForPan("5555444433332222")
-        val hardCodedBrands = listOf(newCardBrand?.name, hardCodedBrand?.name)
-        Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+        if (isPanRequiredLength()) {
+            val hardCodedBrand = findBrandForPan("5555444433332222")
+            val hardCodedBrands = listOf(newCardBrand?.name, hardCodedBrand?.name)
+            Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+        }
     }
 
     private fun isPanRequiredLength(): Boolean {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcher.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.validation.listeners.text
 
 import android.text.Editable
+import android.util.Log
 import android.widget.EditText
 import com.worldpay.access.checkout.api.configuration.CardValidationRule
 import com.worldpay.access.checkout.api.configuration.RemoteCardBrand
@@ -35,6 +36,7 @@ internal class PanTextWatcher(
 
     private var expectedCursorPosition = 0
     private var isSpaceDeleted = false
+    private val requiredPanLengthForScheme = 12
 
     override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
         super.beforeTextChanged(s, start, count, after)
@@ -46,9 +48,9 @@ internal class PanTextWatcher(
      * This function is called whenever the text is being changed in the UI.
      * The override is responsible for calculating where the cursor position should be after the text changes
      *
-     * @param start - the position of cursor when text changed
-     * @param before - the number of characters changed
-     * @param count - number of characters added
+     * @param start the position of cursor when text changed
+     * @param before the number of characters changed
+     * @param count number of characters added
      */
     override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
         super.onTextChanged(s, start, before, count)
@@ -86,7 +88,6 @@ internal class PanTextWatcher(
             clearPanBefore()
             return
         }
-
         handleCardBrandChange(brand)
         validate(newPan, cardValidationRule, brand)
 
@@ -209,6 +210,8 @@ internal class PanTextWatcher(
      * rule of the new card brand
      */
     private fun handleCardBrandChange(newCardBrand: RemoteCardBrand?) {
+        if (isPanRequiredLength()) logCardBrands(newCardBrand)
+
         if (cardBrand == newCardBrand) return
 
         cardBrand = newCardBrand
@@ -239,5 +242,17 @@ internal class PanTextWatcher(
         // where cursorPosition is beyond the text length
         val selection = min(cursorPosition, text.length)
         panEditText.setSelection(selection)
+    }
+
+    private fun logCardBrands(newCardBrand: RemoteCardBrand?) {
+        val hardCodedBrand = findBrandForPan("5555444433332222")
+        val hardCodedBrands = listOf(newCardBrand?.name, hardCodedBrand?.name)
+        Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+    }
+
+    private fun isPanRequiredLength(): Boolean {
+        val pan = panEditText.text.toString()
+        val formattedPan = pan.replace(" ", "").length
+        return (formattedPan >= requiredPanLengthForScheme)
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
@@ -9,7 +9,7 @@ internal class BrandsChangedHandler(
     private val toCardBrandTransformer: ToCardBrandTransformer
 ) {
 
-    fun handle(remoteCardBrands: List<RemoteCardBrand?>) {
+    fun handle(remoteCardBrands: List<RemoteCardBrand>) {
         val cardBrands = remoteCardBrands.mapNotNull { toCardBrandTransformer.transform(it)}
         validationListener.onBrandsChange(cardBrands)
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
@@ -9,7 +9,7 @@ internal class BrandsChangedHandler(
     private val toCardBrandTransformer: ToCardBrandTransformer
 ) {
 
-    fun handle(remoteCardBrands: List<RemoteCardBrand>) {
+    fun handle(remoteCardBrands: List<RemoteCardBrand?>) {
         val cardBrands = remoteCardBrands.mapNotNull { toCardBrandTransformer.transform(it)}
         validationListener.onBrandsChange(cardBrands)
     }


### PR DESCRIPTION
## What
- notify merchant's validation listener with hard-coded card schemes when user enters card number
## How
- logging the scheme returned 
- hardcoding a second scheme
## Why 
- so that schemes can be returned in preparation for future refactoring