### PR TITLE
NOTICKET: Update .aar name generation to work with AGP7+

### DIFF
--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -56,11 +56,14 @@ android {
 
     libraryVariants.configureEach { variant ->
         variant.outputs.all { output ->
-            if (variant.name == "release" && outputFile != null && outputFileName.endsWith('.aar')) {
-                outputFileName = "${archivesBaseName}-${version}.aar"
-            }
-            if (variant.name == "debug" && outputFile != null && outputFileName.endsWith('.aar')) {
-                outputFileName = "${archivesBaseName}-${version}-debug.aar"
+            def name = "${archivesBaseName}-${version}"
+            if (output.outputFileName.endsWith('.aar')) {
+                if (variant.name == "release") {
+                    output.outputFileName = "${name}.aar"
+                }
+                if (variant.name == "debug") {
+                    output.outputFileName = "${name}-debug.aar"
+                }
             }
         }
     }


### PR DESCRIPTION
### What
- Update .aar name generation to work with AGP7+ as AGP7+ introduced some changes that meant `outputFileName` direct access was deprecated 

### Why

This is so that we can correctly name our `.aar` artefacts when performing a release