### PR TITLE
US2121248: add service layer for brand

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/service/BrandService.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/service/BrandService.kt
@@ -5,27 +5,21 @@ import com.worldpay.access.checkout.api.configuration.RemoteCardBrand
 import com.worldpay.access.checkout.validation.utils.ValidationUtil.findBrandForPan
 
 internal class BrandService {
-    private val requiredPanLengthForCardBrands = 12
-
 
     fun getCardBrands(newCardBrand: RemoteCardBrand?, pan: String): List<RemoteCardBrand> {
         if (newCardBrand == null) {
             return emptyList()
         }
 
-        if (isPanRequiredLength(pan)) {
-            val hardCodedBrand = findBrandForPan("5555444433332222")
-            if (hardCodedBrand != null) {
-                val hardCodedBrands = listOf(newCardBrand, hardCodedBrand)
-                Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
-                return hardCodedBrands
-            }
-        }
-        return listOf(newCardBrand)
-    }
+        //hard code the pan for now, will be remove in future work
+        val hardCodedBrand = findBrandForPan("5555444433332222")
 
-    private fun isPanRequiredLength(pan: String): Boolean {
-        val formattedPan = pan.replace(" ", "").length
-        return (formattedPan >= requiredPanLengthForCardBrands)
+        if (hardCodedBrand != null) {
+            val hardCodedBrands = listOf(newCardBrand, hardCodedBrand)
+            Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+            return hardCodedBrands
+        }
+
+        return listOf(newCardBrand)
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/service/BrandService.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/service/BrandService.kt
@@ -1,0 +1,31 @@
+package com.worldpay.access.checkout.service
+
+import android.util.Log
+import com.worldpay.access.checkout.api.configuration.RemoteCardBrand
+import com.worldpay.access.checkout.validation.utils.ValidationUtil.findBrandForPan
+
+internal class BrandService {
+    private val requiredPanLengthForCardBrands = 12
+
+
+    fun getCardBrands(newCardBrand: RemoteCardBrand?, pan: String): List<RemoteCardBrand> {
+        if (newCardBrand == null) {
+            return emptyList()
+        }
+
+        if (isPanRequiredLength(pan)) {
+            val hardCodedBrand = findBrandForPan("5555444433332222")
+            if (hardCodedBrand != null) {
+                val hardCodedBrands = listOf(newCardBrand, hardCodedBrand)
+                Log.d(javaClass.simpleName, "Available brands for card: $hardCodedBrands")
+                return hardCodedBrands
+            }
+        }
+        return listOf(newCardBrand)
+    }
+
+    private fun isPanRequiredLength(pan: String): Boolean {
+        val formattedPan = pan.replace(" ", "").length
+        return (formattedPan >= requiredPanLengthForCardBrands)
+    }
+}

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/TextWatcherFactory.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/listeners/text/TextWatcherFactory.kt
@@ -1,6 +1,7 @@
 package com.worldpay.access.checkout.validation.listeners.text
 
 import android.widget.EditText
+import com.worldpay.access.checkout.service.BrandService
 import com.worldpay.access.checkout.validation.formatter.PanFormatter
 import com.worldpay.access.checkout.validation.result.handler.ResultHandlerFactory
 import com.worldpay.access.checkout.validation.validators.CVCValidationRuleManager
@@ -14,6 +15,7 @@ internal class TextWatcherFactory(
 
     private val cvcValidationRuleManager = CVCValidationRuleManager()
     private val dateValidator = ExpiryDateValidator()
+    private val brandService = BrandService()
 
     fun createPanTextWatcher(
         panEditText: EditText,
@@ -32,7 +34,8 @@ internal class TextWatcherFactory(
             cvcAccessEditText = cvcEditText,
             panValidationResultHandler = resultHandlerFactory.getPanValidationResultHandler(),
             brandsChangedHandler = resultHandlerFactory.getBrandsChangedHandler(),
-            cvcValidationRuleManager = cvcValidationRuleManager
+            cvcValidationRuleManager = cvcValidationRuleManager,
+            brandService
         )
     }
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
@@ -9,7 +9,7 @@ internal class BrandsChangedHandler(
     private val toCardBrandTransformer: ToCardBrandTransformer
 ) {
 
-    fun handle(remoteCardBrands: List<RemoteCardBrand?>) {
+    fun handle(remoteCardBrands: List<RemoteCardBrand>) {
         val cardBrands = remoteCardBrands.mapNotNull { toCardBrandTransformer.transform(it)}
         validationListener.onBrandsChange(cardBrands)
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/validation/result/handler/BrandsChangedHandler.kt
@@ -9,7 +9,7 @@ internal class BrandsChangedHandler(
     private val toCardBrandTransformer: ToCardBrandTransformer
 ) {
 
-    fun handle(remoteCardBrands: List<RemoteCardBrand>) {
+    fun handle(remoteCardBrands: List<RemoteCardBrand?>) {
         val cardBrands = remoteCardBrands.mapNotNull { toCardBrandTransformer.transform(it)}
         validationListener.onBrandsChange(cardBrands)
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/service/BrandServiceTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/service/BrandServiceTest.kt
@@ -23,7 +23,7 @@ class BrandServiceTest {
         private val brandService = BrandService()
 
         @Test
-        fun `should return an array with a single brand when pan is required length but unable to find brand`() {
+        fun `should return an list with a single brand when unable to find brand for pan`() {
             val brand = VISA_BRAND
             val expected = listOf(brand)
             val result = brandService.getCardBrands(brand, "1234123412341234")
@@ -46,24 +46,14 @@ class BrandServiceTest {
         }
 
         @Test
-        fun `should return an empty array when brand is null`() {
+        fun `should return an empty list when brand is null`() {
             val result = brandService.getCardBrands(null, testPan)
 
             assertEquals(result, emptyList())
         }
 
         @Test
-        fun `should return an array with a single brand when pan is below required length`() {
-            val panBelowRequiredLength = "44443333222"
-            val brand = VISA_BRAND
-            val expected = listOf(brand)
-            val result = brandService.getCardBrands(brand, panBelowRequiredLength)
-
-            assertEquals(result, expected)
-        }
-
-        @Test
-        fun `should return a array of brands when pan is required length`() {
+        fun `should return a list of brands when able to find brand for pan`() {
             val brand = VISA_BRAND
             val result = brandService.getCardBrands(brand, testPan)
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/service/BrandServiceTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/service/BrandServiceTest.kt
@@ -1,0 +1,74 @@
+package com.worldpay.access.checkout.service
+
+import com.worldpay.access.checkout.testutils.CardConfigurationUtil.Brands.VISA_BRAND
+import com.worldpay.access.checkout.testutils.CardConfigurationUtil.mockSuccessfulCardConfiguration
+import com.worldpay.access.checkout.testutils.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+
+@RunWith(Enclosed::class)
+@ExperimentalCoroutinesApi
+class BrandServiceTest {
+
+    // Runs tests without mock card configuration
+    class WithoutBrandDetection() {
+        private val brandService = BrandService()
+
+        @Test
+        fun `should return an array with a single brand when pan is required length but unable to find brand`() {
+            val brand = VISA_BRAND
+            val expected = listOf(brand)
+            val result = brandService.getCardBrands(brand, "1234123412341234")
+
+            assertEquals(result, expected)
+        }
+    }
+
+    // Runs tests with mock card configuration to detect brands
+    class WithBrandDetection() {
+        @get:Rule
+        var coroutinesTestRule = CoroutineTestRule()
+
+        private val brandService = BrandService()
+        private val testPan = "4444333322221111"
+
+        @Before
+        fun setup() = runBlockingTest {
+            mockSuccessfulCardConfiguration()
+        }
+
+        @Test
+        fun `should return an empty array when brand is null`() {
+            val result = brandService.getCardBrands(null, testPan)
+
+            assertEquals(result, emptyList())
+        }
+
+        @Test
+        fun `should return an array with a single brand when pan is below required length`() {
+            val panBelowRequiredLength = "44443333222"
+            val brand = VISA_BRAND
+            val expected = listOf(brand)
+            val result = brandService.getCardBrands(brand, panBelowRequiredLength)
+
+            assertEquals(result, expected)
+        }
+
+        @Test
+        fun `should return a array of brands when pan is required length`() {
+            val brand = VISA_BRAND
+            val result = brandService.getCardBrands(brand, testPan)
+
+            assertTrue(brand in result)
+            assertEquals(2, result.count())
+        }
+    }
+}

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcherTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/validation/listeners/text/PanTextWatcherTest.kt
@@ -2,6 +2,7 @@ package com.worldpay.access.checkout.validation.listeners.text
 
 import android.text.Editable
 import android.widget.EditText
+import com.worldpay.access.checkout.service.BrandService
 import com.worldpay.access.checkout.testutils.CardConfigurationUtil.Brands.VISA_BRAND
 import com.worldpay.access.checkout.testutils.CardConfigurationUtil.mockSuccessfulCardConfiguration
 import com.worldpay.access.checkout.testutils.CardNumberUtil.INVALID_UNKNOWN_LUHN
@@ -48,6 +49,8 @@ class PanTextWatcherTest {
 
     private lateinit var panTextWatcher: PanTextWatcher
 
+    private val brandService = mock<BrandService>()
+
     @Before
     fun setup() = runAsBlockingTest {
         mockSuccessfulCardConfiguration()
@@ -60,7 +63,8 @@ class PanTextWatcherTest {
             cvcAccessEditText = cvcEditText,
             panValidationResultHandler = panValidationResultHandler,
             brandsChangedHandler = brandsChangedHandler,
-            cvcValidationRuleManager = cvcValidationRuleManager
+            cvcValidationRuleManager = cvcValidationRuleManager,
+            brandService = brandService
         )
 
         given(cvcEditText.text).willReturn(cvcEditable)
@@ -120,6 +124,7 @@ class PanTextWatcherTest {
     fun `should call the brand changed handler with visa brand regardless of the pan validation result being INVALID`() {
         mockPan(visaPan(), VALID)
         given(panFormatter.format(visaPan(), VISA_BRAND)).willReturn(visaPan())
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
 
         panTextWatcher.afterTextChanged(panEditable)
         verify(brandsChangedHandler).handle(listOf(VISA_BRAND))
@@ -135,6 +140,7 @@ class PanTextWatcherTest {
     fun `should call the brand changed handler with visa brand regardless of the pan validation result being CARD_BRAND_NOT_ACCEPTED`() {
         mockPan(visaPan(), VALID)
         given(panFormatter.format(visaPan(), VISA_BRAND)).willReturn(visaPan())
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
 
         panTextWatcher.afterTextChanged(panEditable)
         verify(brandsChangedHandler).handle(listOf(VISA_BRAND))
@@ -150,6 +156,7 @@ class PanTextWatcherTest {
     fun `should call the brand changed handler with visa brand regardless of the pan validation result being INVALID_LUHN`() {
         mockPan(visaPan(), VALID)
         given(panFormatter.format(visaPan(), VISA_BRAND)).willReturn(visaPan())
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
 
         panTextWatcher.afterTextChanged(panEditable)
         verify(brandsChangedHandler).handle(listOf(VISA_BRAND))
@@ -180,6 +187,8 @@ class PanTextWatcherTest {
     fun `should not call the brand changed handler if the brand has not actually changed from the previous one`() {
         // set the visa pan so that the brand changed handler is called with visa
         mockPan(visaPan(), VALID)
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
+
         panTextWatcher.afterTextChanged(panEditable)
         verify(brandsChangedHandler).handle(listOf(VISA_BRAND))
 
@@ -194,6 +203,8 @@ class PanTextWatcherTest {
     @Test
     fun `should update the cvc validation rule when the brand changes`() {
         mockPan(visaPan(), VALID)
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
+
 
         panTextWatcher.afterTextChanged(panEditable)
 
@@ -205,6 +216,7 @@ class PanTextWatcherTest {
     fun `should re-validate the cvc when the brand changes`() {
         mockPan(visaPan(), VALID)
         given(cvcEditable.toString()).willReturn("123")
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
 
         panTextWatcher.afterTextChanged(panEditable)
 
@@ -216,6 +228,8 @@ class PanTextWatcherTest {
     fun `should not interact with the cvc validator at all if the brand has not changed`() {
         // set the visa pan so that the brand changed handler is called with visa
         mockPan(visaPan(), VALID)
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
+
         panTextWatcher.afterTextChanged(panEditable)
         verify(brandsChangedHandler).handle(listOf(VISA_BRAND))
 
@@ -232,6 +246,7 @@ class PanTextWatcherTest {
     fun `should not interact with the cvc validator at all if the cvc is empty`() {
         mockPan(visaPan(), VALID)
         given(cvcEditable.toString()).willReturn("")
+        given(brandService.getCardBrands(any(), any())).willReturn(listOf(VISA_BRAND))
 
         panTextWatcher.afterTextChanged(panEditable)
 


### PR DESCRIPTION
## What
- Refactor code to introduce service layer that notifies merchant validation listener with hard-coded card schemes
## How
- move the logic to retrieve the card brands to the service layer
- add tests
## Why 
- so that our SDK is in line with our architectural principles. 
- so that future changes can be isolated from other areas of code