### PR TITLE
US2123825: update brands displayed in demo app when empty list of brands is returned

### DIFF
--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/card/CardValidationListener.kt
@@ -33,18 +33,17 @@ class CardValidationListener(private val activity: FragmentActivity) :
 
     override fun onBrandsChange(cardBrands: List<CardBrand>) {
         val brandLogo = activity.findViewById<ImageView>(R.id.card_flow_brand_logo)
-        val cardBrandNameTextView = activity.findViewById<TextView>(R.id.card_flow_text_card_brand_name)
         if (brandLogo != null) {
             // currently just applying first card logo returned in list
             // as underlying functionality to display two logos doesn't exist yet
             // will be displayed in demo application as csv values below card number field
             val cardBrand = if (cardBrands.isEmpty()) null else cardBrands.first()
             getInstance(activity).fetchAndApplyCardLogo(cardBrand, brandLogo)
-            val cardBrandList = if (cardBrands.isEmpty()) null else cardBrands.joinToString(", ") { it.name }
-            if (cardBrandList != null) {
-                // we then set the text of the list of card brands to the text view
-                cardBrandNameTextView.text = cardBrandList
-            }
+            val cardBrandList =
+                if (cardBrands.isEmpty()) null else cardBrands.joinToString(", ") { it.name }
+
+            // we then set the text of the list of card brands to the text view
+            if (cardBrandList != null) setCardBrandText(cardBrandList) else setCardBrandText("")
         } else {
             Log.d(
                 this::class.java.simpleName,
@@ -67,5 +66,11 @@ class CardValidationListener(private val activity: FragmentActivity) :
         } else {
             accessCheckoutEditText.setTextColor(invalidColor)
         }
+    }
+
+    private fun setCardBrandText(text: String?) {
+        val cardBrandNameTextView =
+            activity.findViewById<TextView>(R.id.card_flow_text_card_brand_name)
+        cardBrandNameTextView.text = text
     }
 }


### PR DESCRIPTION
## What
- Notify merchant's validation listener with empty list of card schemes when shopper clears field
## How
- clear text field when an empty list is passed 
## Why
- so that the merchant (and the demo app) can display schemes consistently 