### PR TITLE
US2125522 - Add UI test to cover functionality of the cardBrandName

### DIFF
--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -2,6 +2,7 @@ package com.worldpay.access.checkout.sample.card.standard.testutil
 
 import android.widget.Button
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.widget.SwitchCompat
 import androidx.core.view.isVisible
 import androidx.test.espresso.Espresso.onView
@@ -24,6 +25,8 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
     private fun expiryDateInput() = findById<AccessCheckoutEditText>(R.id.card_flow_expiry_date)
     private fun submitButton() = findById<Button>(R.id.card_flow_btn_submit)
     private fun brandLogo() = findById<ImageView>(R.id.card_flow_brand_logo)
+
+    private fun brandName() = findById<TextView>(R.id.card_flow_text_card_brand_name)
     private fun paymentsCvcSwitch() = findById<SwitchCompat>(R.id.card_flow_payments_cvc_switch)
 
     enum class Input {
@@ -208,6 +211,11 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
 
     fun hasBrand(cardBrand: CardBrand): CardFragmentTestUtils {
         wait(maxWaitTimeInMillis = 20000) { assertEquals(cardBrand.cardBrandName, brandLogo().getTag(R.integer.card_tag)) }
+        return this
+    }
+
+    fun hasBrandName(cardBrandNme: String): CardFragmentTestUtils {
+        wait(maxWaitTimeInMillis = 20000) { assertEquals(cardBrandNme, brandName().text, "Card brand name does not match expected value.") }
         return this
     }
 }

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -218,4 +218,12 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
         wait(maxWaitTimeInMillis = 20000) { assertEquals(cardBrandNme, brandName().text, "Card brand name does not match expected value.") }
         return this
     }
+
+    fun removeLastPanDigit(): CardFragmentTestUtils {
+        val pan = retrieveEnteredText(panInput())
+        if (pan.isNotEmpty()) {
+            enterText(panInput(), pan.substring(0, pan.length - 1))
+        }
+        return this
+    }
 }

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/PANValidationUITest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/PANValidationUITest.kt
@@ -1,5 +1,3 @@
-package com.worldpay.access.checkout.sample.card.standard
-
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.worldpay.access.checkout.sample.card.CardNumberUtil.INVALID_UNKNOWN_LUHN
@@ -70,6 +68,16 @@ class PANValidationUITest : AbstractCardFragmentTest() {
             .hasBrand(AMEX)
             .focusOn(CVC)
             .validationStateIs(pan = false)
+    }
+
+    @Test
+    fun shouldDisplayBrandName() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasNoBrand()
+            .enterCardDetails(pan = "4111111111111111")
+            .hasBrand(VISA)
+            .hasBrandName("visa, mastercard")
     }
 
     @Test

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/PANValidationUITest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/PANValidationUITest.kt
@@ -71,13 +71,40 @@ class PANValidationUITest : AbstractCardFragmentTest() {
     }
 
     @Test
-    fun shouldDisplayBrandName() {
+    fun shouldDisplayBrandNameWhenPanIsValidated() {
         cardFragmentTestUtils
             .isInInitialState()
             .hasNoBrand()
             .enterCardDetails(pan = "4111111111111111")
             .hasBrand(VISA)
             .hasBrandName("visa, mastercard")
+    }
+
+    @Test
+    fun shouldDisplayOneBrandNameWhenOneDigitFromValidPanIsRemoved() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasNoBrand()
+            .enterCardDetails(pan = "444433332222")
+            .hasBrand(VISA)
+            .hasBrandName("visa, mastercard")
+            .setCursorPositionOnPan(11)
+            .removeLastPanDigit()
+            .hasBrandName("visa")
+    }
+
+    @Test
+    fun shouldShowNoBrandsWhenValidPanIsCleared() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasNoBrand()
+            .enterCardDetails(pan = "4111111111111111")
+            .hasBrand(VISA)
+            .hasBrandName("visa, mastercard")
+        clearPan()
+        cardFragmentTestUtils
+            .hasNoBrand()
+            .hasBrandName("")
     }
 
     @Test


### PR DESCRIPTION
### **What**

 Add UI tests to cover the co-branded cards functionality

### **How**

Add new tests to cover the cardBrandName functionality

### **Why**

So that I have an acceptance level test that I can use for testing against regressions during development