### PR TITLE
US2123827: fix issue in CardBinService that causes apps to crash

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/cardbin/api/client/CardBinClient.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/cardbin/api/client/CardBinClient.kt
@@ -90,11 +90,10 @@ internal class CardBinClient(
 
                     // Resume the coroutine with the response
                     continuation.resume(response)
-                } catch (_: Exception) {
+                } catch (e: Exception) {
                     //Otherwise raise new exception
                     continuation.resumeWithException(
-                        //TODO: Do we need any details ?
-                        AccessCheckoutException("Could not perform request to card-bin API.")
+                        AccessCheckoutException("${e.message}")
                     )
                 }
             }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/cardbin/api/service/CardBinService.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/cardbin/api/service/CardBinService.kt
@@ -1,16 +1,13 @@
 package com.worldpay.access.checkout.cardbin.api.service
 
-import com.worldpay.access.checkout.api.HttpsClient
+import android.util.Log
 import com.worldpay.access.checkout.api.configuration.RemoteCardBrand
 import com.worldpay.access.checkout.cardbin.api.client.CardBinClient
 import com.worldpay.access.checkout.cardbin.api.request.CardBinRequest
 import com.worldpay.access.checkout.cardbin.api.response.CardBinResponse
-import com.worldpay.access.checkout.cardbin.api.serialization.CardBinRequestSerializer
-import com.worldpay.access.checkout.cardbin.api.serialization.CardBinResponseDeserializer
-import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
@@ -31,9 +28,6 @@ internal class CardBinService(
     ),
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
-
-    // Holds the current in-flight request Job for cancellation
-    internal var currentJob: Job? = null
 
     companion object {
         // only stores value in cache of required length (12 digits)
@@ -81,17 +75,29 @@ internal class CardBinService(
             return
         }
 
-        // Launch a coroutine to fetch the card brands from the API asynchronously
-        launchCancellableCoroutineRequest {
-            val response =
-                client.getCardBinResponse(request = CardBinRequest(panValue, checkoutId))
-            // Transform the API response into a list of card brands
-            val brands = transform(globalBrand, response)
-            cache[cacheKey] = brands
+        val coroutineExceptionHandler =
+            CoroutineExceptionHandler { _, throwable ->
+                Log.d(
+                    this::class.java.simpleName,
+                    "Could not retrieve card bin information using API client: ${throwable.message}"
+                )
+                callback.invoke(listOf(globalBrand))
+            }
 
-            // Invoke the callback with the transformed card brands
-            callback.invoke(brands)
-        }
+        // Launch a coroutine to fetch the card brands from the API asynchronously
+        launchCancellableCoroutineRequest(
+            {
+                val response =
+                    client.getCardBinResponse(request = CardBinRequest(panValue, checkoutId))
+                // Transform the API response into a list of card brands
+                val brands = transform(globalBrand, response)
+                cache[cacheKey] = brands
+
+                // Invoke the callback with the transformed card brands
+                callback.invoke(brands)
+            },
+            coroutineExceptionHandler
+        )
     }
 
     /**
@@ -103,30 +109,14 @@ internal class CardBinService(
      * @param request A suspendable lambda representing the request to be executed.
      */
     private fun launchCancellableCoroutineRequest(
-        request: suspend () -> Unit
+        request: suspend () -> Unit,
+        coroutineExceptionHandler: CoroutineExceptionHandler
     ) {
-        currentJob?.let {
-            println("Found in-flight request, will abort in-flight request.")
-            it.cancel() // Cancel the in-flight request
-            currentJob = null // Reset the job reference
-        }
-
         // Launch a new coroutine to execute the request
-        currentJob = scope.launch {
-            try {
-                // Execute the provided request
-                request()
-            } catch (exception: Exception) {
-                // Wrap and rethrow the exception with additional context
-                throw AccessCheckoutException(
-                    "Could not perform request to card-bin API.",
-                    exception
-                )
-            } finally {
-                currentJob = null
-            }
+        scope.launch(coroutineExceptionHandler) {
+            // Execute the provided request
+            request()
         }
-
     }
 
     private fun transform(

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/cardbin/client/CardBinClientTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/cardbin/client/CardBinClientTest.kt
@@ -91,7 +91,6 @@ class CardBinClientTest {
         assertEquals(cardBinResponse, actualResponse)
     }
 
-
     @Test
     fun `should wrap exception in AccessCheckoutException`() = runTest {
         val client = createCardBinClient()
@@ -109,7 +108,7 @@ class CardBinClientTest {
         val ex = runCatching { client.getCardBinResponse(cardBinRequest) }.exceptionOrNull()
 
         assertTrue(ex is AccessCheckoutException)
-        assertEquals("Could not perform request to card-bin API.", ex?.message)
+        assertEquals("Some error", ex?.message)
     }
 
     @Test


### PR DESCRIPTION
### What
- ix issue in CardBinService that causes apps to crash when coroutine to fetch card bin details is cancelled. Exceptions are now swallowed and logged and the callback passed to the CardBinService is called with the global brand