### PR TITLE
NOTICKET: fix to build broken by changes to run instrumented tests in build

### DIFF
--- a/access-checkout/gradle/jacoco.gradle
+++ b/access-checkout/gradle/jacoco.gradle
@@ -28,15 +28,26 @@ def classDirs = files([
         fileTree(dir: "${layout.buildDirectory.dir('.').get().asFile}/tmp/kotlin-classes/debug", excludes: fileFilter)
 ])
 
-def execData = files("${layout.buildDirectory.dir('.').get().asFile}/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+def execData = files(
+        // Unit test execution data
+        "${layout.buildDirectory.dir('.').get().asFile}/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec",
+        // Android instrumented tests execution data
+        fileTree(
+                dir: "${layout.buildDirectory.dir('.').get().asFile}/outputs/code_coverage/debugAndroidTest/connected/",
+                includes: ["**/*.ec"]
+        )
+)
 
 def sourceDirs = files(["${project.projectDir}/src/main/java"])
 
 tasks.register('jacocoTestReport', JacocoReport) {
-    dependsOn['testDebugUnitTest']
     executionData.setFrom(execData)
     classDirectories.setFrom(classDirs)
     sourceDirectories.setFrom(sourceDirs)
+}
+tasks.named('jacocoTestReport') {
+    dependsOn('connectedDebugAndroidTest')
+    dependsOn('testDebugUnitTest')
 }
 
 tasks.register('jacocoTestCoverageVerification', JacocoCoverageVerification) {


### PR DESCRIPTION
### What
- fix to build broken by changes to run instrumented tests in build

### How
- change Gradle config to always run instrumented tests when producing Jacoco test report
- modify code coverage to use instrumented tests execution data in addition to unit tests execution data