### PR TITLE
Us2193517 add card bin service discovery

### DIFF
--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/ApiDiscoveryStubs.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/api/ApiDiscoveryStubs.kt
@@ -22,6 +22,9 @@ object ApiDiscoveryStubs {
                         "service:sessions": {
                             "href": "{{request.requestLine.baseUrl}}/sessions"
                         },
+                        "cardBinPublic:binDetails": {
+                            "href": "{{request.requestLine.baseUrl}}/public/card/bindetails"
+                        },
                         "curies": [
                             {
                                 "href": "{{request.requestLine.baseUrl}}/rels/payments/{rel}",

--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserIntegrationTest.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserIntegrationTest.kt
@@ -65,16 +65,18 @@ class AccessCheckoutValidationInitialiserIntegrationTest {
     }
 
     @Test
-    fun shouldDiscoverCardSessionsAndCvcSessionsEndPointsWhenInitialisingCardValidation() {
+    fun shouldDiscover_CardSessions_CvcSessions_CardBinDetails_endPointsWhenInitialisingCardValidation() {
         val expectedKey1InDiscoveryCache = "service:sessions,sessions:card"
         val expectedKey2InDiscoveryCache = "service:sessions,sessions:paymentsCvc"
+        val expectedKey3InDiscoveryCache = "cardBinPublic:binDetails"
 
         AccessCheckoutValidationInitialiser.initialise(cardValidationConfig())
 
         await().atMost(timeout, SECONDS).until {
-            DiscoveryCache.results.size == 2
+            DiscoveryCache.results.size == 3
                     && DiscoveryCache.results.containsKey(expectedKey1InDiscoveryCache)
                     && DiscoveryCache.results.containsKey(expectedKey2InDiscoveryCache)
+                    && DiscoveryCache.results.containsKey(expectedKey3InDiscoveryCache)
         }
     }
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/ApiDiscoveryClient.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/ApiDiscoveryClient.kt
@@ -67,10 +67,10 @@ internal class ApiDiscoveryClient(
     }
 
     private suspend fun discover(baseUrl: URL, endpoints: List<Endpoint>): URL {
-        Log.d(javaClass.simpleName, "Sending request to service discovery endpoint")
-
         var resourceUrl = baseUrl
         for (endpoint in endpoints) {
+            Log.d(javaClass.simpleName, "Discovering endpoint for ${endpoint.key}")
+
             var response = discoveryCache.getResponse(resourceUrl)
             response?.let {
                 Log.d(javaClass.simpleName, "Retrieved response from cache for $resourceUrl")
@@ -82,9 +82,9 @@ internal class ApiDiscoveryClient(
             }
 
             resourceUrl = urlFactory.getURL(endpoint.getDeserializer().deserialize(response))
+            Log.d(javaClass.simpleName, "Success. Found: $resourceUrl")
         }
 
-        Log.d(javaClass.simpleName, "Received response from service discovery endpoint")
         return resourceUrl
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/DiscoverLinks.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/DiscoverLinks.kt
@@ -33,5 +33,11 @@ internal class DiscoverLinks(val endpoints: List<Endpoint>) : Serializable {
                 )
             )
         )
+
+        val cardBinDetails = DiscoverLinks(
+            listOf(
+                Endpoint("cardBinPublic:binDetails")
+            )
+        )
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiser.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiser.kt
@@ -51,6 +51,10 @@ object AccessCheckoutValidationInitialiser {
                         URL(validationConfig.baseUrl),
                         discoverLinks = DiscoverLinks.cvcSessions
                     )
+                    apiDiscoveryClient.discoverEndpoint(
+                        URL(validationConfig.baseUrl),
+                        discoverLinks = DiscoverLinks.cardBinDetails
+                    )
                 } catch (e: AccessCheckoutException) {
                     Log.w(javaClass.simpleName, "Failed to discover services", e)
                 }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/api/discovery/DiscoverLinksTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/api/discovery/DiscoverLinksTest.kt
@@ -1,38 +1,57 @@
 package com.worldpay.access.checkout.api.discovery
 
 import com.worldpay.access.checkout.session.api.client.SESSIONS_MEDIA_TYPE
-import kotlin.test.assertEquals
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class DiscoverLinksTest {
 
     @Test
     fun `discoverLinks cvcSessions should return keys used to discover service and endpoint for cvc sessions`() {
-        val expectedService = "service:sessions"
-        val expectedEndpoint = "sessions:paymentsCvc"
+        val expectedKeySessionsService = "service:sessions"
+        val expectedKeyCvcSessionsEndpoint = "sessions:paymentsCvc"
 
-        assertEquals(DiscoverLinks.cvcSessions.endpoints[0].key, expectedService)
-        assertEquals(DiscoverLinks.cvcSessions.endpoints[1].key, expectedEndpoint)
+        assertEquals(2, DiscoverLinks.cvcSessions.endpoints.size)
+        assertEquals(DiscoverLinks.cvcSessions.endpoints[0].key, expectedKeySessionsService)
+        assertEquals(DiscoverLinks.cvcSessions.endpoints[1].key, expectedKeyCvcSessionsEndpoint)
     }
 
     @Test
     fun `discoverLinks cvcSessions should return headers for sessions service`() {
         assertEquals(DiscoverLinks.cvcSessions.endpoints[1].headers["Accept"], SESSIONS_MEDIA_TYPE)
-        assertEquals(DiscoverLinks.cvcSessions.endpoints[1].headers["Content-Type"], SESSIONS_MEDIA_TYPE)
+        assertEquals(
+            DiscoverLinks.cvcSessions.endpoints[1].headers["Content-Type"],
+            SESSIONS_MEDIA_TYPE
+        )
     }
 
     @Test
     fun `discoverLinks cardSessions should return keys used to discover service and endpoint for card sessions`() {
-        val expectedService = "service:sessions"
-        val expectedEndpoint = "sessions:card"
+        val expectedKeySessionsService = "service:sessions"
+        val expectedCardSessionsEndpoint = "sessions:card"
 
-        assertEquals(DiscoverLinks.cardSessions.endpoints[0].key, expectedService)
-        assertEquals(DiscoverLinks.cardSessions.endpoints[1].key, expectedEndpoint)
+        assertEquals(2, DiscoverLinks.cvcSessions.endpoints.size)
+        assertEquals(DiscoverLinks.cardSessions.endpoints[0].key, expectedKeySessionsService)
+        assertEquals(DiscoverLinks.cardSessions.endpoints[1].key, expectedCardSessionsEndpoint)
     }
 
     @Test
     fun `discoverLinks cardSessions should return headers for sessions service`() {
         assertEquals(DiscoverLinks.cardSessions.endpoints[1].headers["Accept"], SESSIONS_MEDIA_TYPE)
-        assertEquals(DiscoverLinks.cardSessions.endpoints[1].headers["Content-Type"], SESSIONS_MEDIA_TYPE)
+        assertEquals(
+            DiscoverLinks.cardSessions.endpoints[1].headers["Content-Type"],
+            SESSIONS_MEDIA_TYPE
+        )
+    }
+
+    @Test
+    fun `discoverLinks cardBinDetails should return keys used to discover card bin details endpoint`() {
+        val expectedKeyCardBinDetailsEndpoint = "cardBinPublic:binDetails"
+
+        assertEquals(1, DiscoverLinks.cardBinDetails.endpoints.size)
+        assertEquals(
+            DiscoverLinks.cardBinDetails.endpoints[0].key,
+            expectedKeyCardBinDetailsEndpoint
+        )
     }
 }


### PR DESCRIPTION
### What
- add discovery of card details details endpoint to card validation initialisation
- improve service discovery debug loga

### Why
- this will be used by the Android SDK CardBinService instead of using hardcoded values today