### PR TITLE
US2168978 ensure properties can be complied on lower apis

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/NoWeakCipherSSLSocketFactory.kt
@@ -2,8 +2,6 @@ package com.worldpay.access.checkout.api
 
 import java.net.InetAddress
 import java.net.Socket
-import java.util.Arrays
-import java.util.stream.Collectors.toList
 import javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
@@ -12,10 +10,8 @@ internal class NoWeakCipherSSLSocketFactory constructor(
     private val defaultSSLSocketFactory: SSLSocketFactory
 ) : SSLSocketFactory() {
 
-    private val enabledCipherSuites: Array<String> = Arrays
-        .stream(defaultSSLSocketFactory.defaultCipherSuites)
-        .filter { !it.endsWith("SHA", ignoreCase = true) }
-        .collect(toList())
+    private val enabledCipherSuites: Array<String> = defaultSSLSocketFactory.defaultCipherSuites
+        .mapNotNull { it.takeIf { cipher -> !cipher.endsWith("SHA", ignoreCase = true) } }
         .toTypedArray()
 
     companion object {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/DiscoveryCache.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/api/discovery/DiscoveryCache.kt
@@ -41,11 +41,9 @@ internal object DiscoveryCache {
     }
 
     /**
-     * Converts a DiscoverLinks into a comma-separate String made of each EndPoint endpoint
+     * Converts a DiscoverLinks into a comma-separate String made of each endpoint
      * This String is used to store or lookup a result in the results Map
      */
     private fun convertToKey(discoverLinks: DiscoverLinks) =
-        discoverLinks.endpoints.stream()
-            .map { it.endpoint }
-            .collect(Collectors.joining(","))
+        discoverLinks.endpoints.joinToString(separator = ",") { it.endpoint }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -11,7 +11,6 @@ import android.text.InputFilter
 import android.text.SpannableStringBuilder
 import android.text.method.KeyListener
 import android.util.AttributeSet
-import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
@@ -21,7 +20,7 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.StyleRes
 import androidx.core.widget.TextViewCompat
 import com.worldpay.access.checkout.R
-import com.worldpay.access.checkout.util.BuildVersionProvider
+import com.worldpay.access.checkout.util.BuildVersionProviderHolder
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -32,8 +31,7 @@ class AccessCheckoutEditText internal constructor(
     context: Context,
     attrs: AttributeSet?,
     defStyle: Int,
-    internal val editText: EditText?,
-    internal var sdk: BuildVersionProvider = BuildVersionProvider(),
+    internal val editText: EditText?
 ) : FrameLayout(context, attrs, defStyle) {
     private var externalOnFocusChangeListener: OnFocusChangeListener? = null
 
@@ -59,7 +57,8 @@ class AccessCheckoutEditText internal constructor(
                 val styledAttributes: TypedArray =
                     context.obtainStyledAttributes(attrs, R.styleable.AccessCheckoutEditText, 0, 0)
 
-                val attributeValues = AttributeValues(styledAttributes, sdk)
+                val attributeValues =
+                    AttributeValues(styledAttributes, BuildVersionProviderHolder.instance)
                 attributeValues.setAttributesOnEditText(editText)
 
                 styledAttributes.recycle()
@@ -277,7 +276,9 @@ class AccessCheckoutEditText internal constructor(
      */
     @RequiresApi(Build.VERSION_CODES.O)
     fun setAutoSizeTextTypeWithDefaults(@TextViewCompat.AutoSizeTextType autoSizeTextType: Int) {
-        if (sdk.isAtLeastO()) editText!!.setAutoSizeTextTypeWithDefaults(autoSizeTextType)
+        if (BuildVersionProviderHolder.instance.isAtLeastO()) editText!!.setAutoSizeTextTypeWithDefaults(
+            autoSizeTextType
+        )
     }
 
     /**
@@ -287,7 +288,9 @@ class AccessCheckoutEditText internal constructor(
      */
     @RequiresApi(Build.VERSION_CODES.M)
     fun setTextAppearance(@StyleRes resId: Int) {
-        if (sdk.isAtLeastM()) editText!!.setTextAppearance(resId)
+        if (BuildVersionProviderHolder.instance.isAtLeastM()) editText!!.setTextAppearance(
+            resId
+        )
     }
 
     internal fun length(): Int = editText!!.length()
@@ -334,12 +337,13 @@ class AccessCheckoutEditText internal constructor(
      */
     @RequiresApi(Build.VERSION_CODES.O)
     override fun setAutofillHints(vararg hints: String?) {
-        if (sdk.isAtLeastO()) editText?.setAutofillHints(*hints)
+        if (BuildVersionProviderHolder.instance.isAtLeastO()) editText?.setAutofillHints(*hints)
     }
+
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun getAutofillHints(): Array<String>? {
-        return if (sdk.isAtLeastO()) {
+        return if (BuildVersionProviderHolder.instance.isAtLeastO()) {
             editText?.autofillHints
         } else {
             null

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
@@ -5,11 +5,12 @@ import android.os.Build
 import android.widget.EditText
 import androidx.annotation.RequiresApi
 import com.worldpay.access.checkout.R
-import com.worldpay.access.checkout.util.BuildVersionProvider
+import com.worldpay.access.checkout.util.BuildVersionProviderHolder
+import com.worldpay.access.checkout.util.IBuildVersionProvider
 
 internal class AttributeValues(
     private val styledAttributes: TypedArray,
-    private val buildVersionProvider: BuildVersionProvider
+    private val buildVersionProvider: IBuildVersionProvider
 ) {
 
     internal fun setAttributesOnEditText(editText: EditText) {
@@ -17,7 +18,7 @@ internal class AttributeValues(
 
         setHintAttribute(editText)
 
-        if (buildVersionProvider.isAtLeastO()) setAutofillAttribute(editText)
+        if (BuildVersionProviderHolder.instance.isAtLeastO()) setAutofillAttribute(editText)
 
         setHintTextColourAttribute(editText)
 
@@ -31,7 +32,7 @@ internal class AttributeValues(
 
         setPaddingAttribute(editText)
 
-        if (buildVersionProvider.isAtLeastO()) setFontAttribute(editText)
+        if (BuildVersionProviderHolder.instance.isAtLeastO()) setFontAttribute(editText)
 
         setEnabledAttribute(editText)
     }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
@@ -1,11 +1,15 @@
 package com.worldpay.access.checkout.ui
 
 import android.content.res.TypedArray
+import android.os.Build
 import android.widget.EditText
+import androidx.annotation.RequiresApi
 import com.worldpay.access.checkout.R
+import com.worldpay.access.checkout.util.BuildVersionProvider
 
 internal class AttributeValues(
-    private val styledAttributes: TypedArray
+    private val styledAttributes: TypedArray,
+    private val buildVersionProvider: BuildVersionProvider
 ) {
 
     internal fun setAttributesOnEditText(editText: EditText) {
@@ -13,7 +17,7 @@ internal class AttributeValues(
 
         setHintAttribute(editText)
 
-        setAutofillAttribute(editText)
+        if (buildVersionProvider.isAtLeastO()) setAutofillAttribute(editText)
 
         setHintTextColourAttribute(editText)
 
@@ -27,7 +31,7 @@ internal class AttributeValues(
 
         setPaddingAttribute(editText)
 
-        setFontAttribute(editText)
+        if (buildVersionProvider.isAtLeastO()) setFontAttribute(editText)
 
         setEnabledAttribute(editText)
     }
@@ -75,6 +79,7 @@ internal class AttributeValues(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun setAutofillAttribute(editText: EditText) {
         val autofill = getAutofillAttribute()
         autofill?.let {
@@ -102,6 +107,7 @@ internal class AttributeValues(
         textColor.takeIf { it != 0 }?.let { editText.setTextColor(textColor) }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun setFontAttribute(editText: EditText) {
         val font = getFontAttribute()
         font?.let { editText.typeface = font }
@@ -169,6 +175,7 @@ internal class AttributeValues(
     private fun getTextColorAttribute() =
         styledAttributes.getColor(R.styleable.AccessCheckoutEditText_android_textColor, 0)
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun getFontAttribute() =
         styledAttributes.getFont(R.styleable.AccessCheckoutEditText_android_font)
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
@@ -3,14 +3,23 @@ package com.worldpay.access.checkout.util
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 
-class BuildVersionProvider {
-    private fun sdkVersion() = Build.VERSION.SDK_INT
+interface IBuildVersionProvider {
+    val sdkInt: Int
+    fun isAtLeastO(): Boolean
+    fun isAtLeastM(): Boolean
+}
+
+class BuildVersionProvider : IBuildVersionProvider {
+    override val sdkInt: Int
+        get() = Build.VERSION.SDK_INT
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
-    fun isAtLeastO() = sdkVersion() >= Build.VERSION_CODES.O
+    override fun isAtLeastO(): Boolean = sdkInt >= Build.VERSION_CODES.O
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.M)
-    fun isAtLeastM() = sdkVersion() >= Build.VERSION_CODES.M
+    override fun isAtLeastM(): Boolean = sdkInt >= Build.VERSION_CODES.M
+}
 
-    fun currentVersion(): Int = Build.VERSION.SDK_INT
+internal object BuildVersionProviderHolder {
+    var instance: IBuildVersionProvider = BuildVersionProvider()
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
@@ -1,0 +1,16 @@
+package com.worldpay.access.checkout.util
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+class BuildVersionProvider {
+    private fun sdkVersion() = Build.VERSION.SDK_INT
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
+    fun isAtLeastO() = sdkVersion() >= Build.VERSION_CODES.O
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.M)
+    fun isAtLeastM() = sdkVersion() >= Build.VERSION_CODES.M
+
+    fun currentVersion(): Int = Build.VERSION.SDK_INT
+}

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/util/BuildVersionProvider.kt
@@ -9,9 +9,9 @@ interface IBuildVersionProvider {
     fun isAtLeastM(): Boolean
 }
 
-class BuildVersionProvider : IBuildVersionProvider {
+class BuildVersionProvider(private val sdkVersion: Int) : IBuildVersionProvider {
     override val sdkInt: Int
-        get() = Build.VERSION.SDK_INT
+        get() = sdkVersion
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
     override fun isAtLeastO(): Boolean = sdkInt >= Build.VERSION_CODES.O
@@ -21,5 +21,5 @@ class BuildVersionProvider : IBuildVersionProvider {
 }
 
 internal object BuildVersionProviderHolder {
-    var instance: IBuildVersionProvider = BuildVersionProvider()
+    var instance: IBuildVersionProvider = BuildVersionProvider(Build.VERSION.SDK_INT)
 }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -30,14 +30,8 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.never
+import org.mockito.kotlin.*
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.given
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.whenever
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -214,6 +208,8 @@ class AccessCheckoutEditTextTest {
 
     @Test
     fun `setAutofillHints() should not call EditText setAutofillHints()`() {
+        whenever(buildProviderMock.isAtLeastO()).thenReturn(true)
+
         val contextMock = mock<Context>()
         val attributeSetMock = mock<AttributeSet>()
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
@@ -1,0 +1,45 @@
+package com.worldpay.access.checkout.util
+
+import android.os.Build
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.intArrayOf
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class BuildVersionProviderTest {
+    val buildVersionProvider = BuildVersionProvider()
+
+    @Test
+    @Config(sdk = [26])
+    fun `currentVersion should return the current SDK version`() {
+        assert(buildVersionProvider.currentVersion() == 26)
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun `isAtLeastO should return true when sdk is 26 or greater`() {
+        assertTrue(buildVersionProvider.isAtLeastO())
+    }
+//
+//    @Test
+//    @Config(sdk = [25])
+//    fun `isAtLeastO should return false when sdk is less than 26`() {
+//        assertFalse(buildVersionProvider.isAtLeastO())
+//    }
+//
+//    @Test
+//    @Config(sdk = [23])
+//    fun `isAtLeastM should return true when sdk is 23 or greater`() {
+//        assertTrue(buildVersionProvider.isAtLeastM())
+//    }
+//
+//    @Test
+//    @Config(sdk = [22])
+//    fun `isAtLeastM should return false when sdk is less than 23`() {
+//        assertFalse(buildVersionProvider.isAtLeastM())
+//    }
+}

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
@@ -1,22 +1,20 @@
 package com.worldpay.access.checkout.util
 
-import android.os.Build
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import kotlin.intArrayOf
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class BuildVersionProviderTest {
-    val buildVersionProvider = BuildVersionProvider()
+    private val buildVersionProvider = BuildVersionProvider()
 
     @Test
     @Config(sdk = [26])
     fun `currentVersion should return the current SDK version`() {
-        assert(buildVersionProvider.currentVersion() == 26)
+        assert(buildVersionProvider.sdkInt == 26)
     }
 
     @Test
@@ -24,22 +22,22 @@ class BuildVersionProviderTest {
     fun `isAtLeastO should return true when sdk is 26 or greater`() {
         assertTrue(buildVersionProvider.isAtLeastO())
     }
-//
-//    @Test
-//    @Config(sdk = [25])
-//    fun `isAtLeastO should return false when sdk is less than 26`() {
-//        assertFalse(buildVersionProvider.isAtLeastO())
-//    }
-//
-//    @Test
-//    @Config(sdk = [23])
-//    fun `isAtLeastM should return true when sdk is 23 or greater`() {
-//        assertTrue(buildVersionProvider.isAtLeastM())
-//    }
-//
-//    @Test
-//    @Config(sdk = [22])
-//    fun `isAtLeastM should return false when sdk is less than 23`() {
-//        assertFalse(buildVersionProvider.isAtLeastM())
-//    }
+
+    @Test
+    @Config(sdk = [25])
+    fun `isAtLeastO should return false when sdk is less than 26`() {
+        assertFalse(buildVersionProvider.isAtLeastO())
+    }
+
+    @Test
+    @Config(sdk = [23])
+    fun `isAtLeastM should return true when sdk is 23 or greater`() {
+        assertTrue(buildVersionProvider.isAtLeastM())
+    }
+
+    @Test
+    @Config(sdk = [22])
+    fun `isAtLeastM should return false when sdk is less than 23`() {
+        assertFalse(buildVersionProvider.isAtLeastM())
+    }
 }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
@@ -1,9 +1,9 @@
 package com.worldpay.access.checkout.util
 
+import android.os.Build
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -12,32 +12,25 @@ class BuildVersionProviderTest {
     private val buildVersionProvider = BuildVersionProvider()
 
     @Test
-    @Config(sdk = [26])
     fun `currentVersion should return the current SDK version`() {
-        assert(buildVersionProvider.sdkInt == 26)
+        assert(buildVersionProvider.sdkInt == Build.VERSION.SDK_INT)
     }
 
     @Test
-    @Config(sdk = [26])
-    fun `isAtLeastO should return true when sdk is 26 or greater`() {
-        assertTrue(buildVersionProvider.isAtLeastO())
+    fun `isAtLeastO should return correct value when sdk version is 23`() {
+        if (Build.VERSION.SDK_INT >= 23) {
+            assertTrue(buildVersionProvider.isAtLeastM())
+        } else {
+            assertFalse(buildVersionProvider.isAtLeastM())
+        }
     }
 
     @Test
-    @Config(sdk = [25])
-    fun `isAtLeastO should return false when sdk is less than 26`() {
-        assertFalse(buildVersionProvider.isAtLeastO())
-    }
-
-    @Test
-    @Config(sdk = [23])
-    fun `isAtLeastM should return true when sdk is 23 or greater`() {
-        assertTrue(buildVersionProvider.isAtLeastM())
-    }
-
-    @Test
-    @Config(sdk = [22])
-    fun `isAtLeastM should return false when sdk is less than 23`() {
-        assertFalse(buildVersionProvider.isAtLeastM())
+    fun `isAtLeastO should return correct value when sdk version is 26`() {
+        if (Build.VERSION.SDK_INT >= 26) {
+            assertTrue(buildVersionProvider.isAtLeastO())
+        } else {
+            assertFalse(buildVersionProvider.isAtLeastO())
+        }
     }
 }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/util/BuildVersionProviderTest.kt
@@ -1,36 +1,49 @@
 package com.worldpay.access.checkout.util
 
-import android.os.Build
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@RunWith(RobolectricTestRunner::class)
+
 class BuildVersionProviderTest {
-    private val buildVersionProvider = BuildVersionProvider()
 
     @Test
-    fun `currentVersion should return the current SDK version`() {
-        assert(buildVersionProvider.sdkInt == Build.VERSION.SDK_INT)
+    fun `sdkInt should return the current SDK version`() {
+        val buildVersionProvider = BuildVersionProvider(23)
+        assert(buildVersionProvider.sdkInt == 23)
     }
 
     @Test
-    fun `isAtLeastO should return correct value when sdk version is 23`() {
-        if (Build.VERSION.SDK_INT >= 23) {
-            assertTrue(buildVersionProvider.isAtLeastM())
-        } else {
-            assertFalse(buildVersionProvider.isAtLeastM())
-        }
+    fun `isAtLeastM should return correct value when sdk version is 23 or greater`() {
+        val buildVersionProvider = BuildVersionProvider(23)
+        assertTrue(buildVersionProvider.isAtLeastM())
+
     }
 
     @Test
-    fun `isAtLeastO should return correct value when sdk version is 26`() {
-        if (Build.VERSION.SDK_INT >= 26) {
-            assertTrue(buildVersionProvider.isAtLeastO())
-        } else {
-            assertFalse(buildVersionProvider.isAtLeastO())
-        }
+    fun `isAtLeastM should return correct value when sdk version is less than 23`() {
+        val buildVersionProvider = BuildVersionProvider(22)
+        assertFalse(buildVersionProvider.isAtLeastM())
+    }
+
+    @Test
+    fun `isAtLeastO should return correct value when sdk version is 26 or greater`() {
+        val buildVersionProvider = BuildVersionProvider(26)
+        assertTrue(buildVersionProvider.isAtLeastO())
+    }
+
+    @Test
+    fun `isAtLeastO should return correct value when sdk version is less than 26`() {
+        val buildVersionProvider = BuildVersionProvider(25)
+        assertFalse(buildVersionProvider.isAtLeastO())
+    }
+
+    @Test
+    fun `BuildVersionProviderHolder instance can be replaced`() {
+        val original = BuildVersionProviderHolder.instance
+        val other = BuildVersionProvider(19)
+        BuildVersionProviderHolder.instance = other
+        assertEquals(19, BuildVersionProviderHolder.instance.sdkInt)
     }
 }


### PR DESCRIPTION
## What 
- ensure API specific properties can be compiled in lower API versions
## How 
- refactor methods that require version 24
- add checks before methods which require versions 23 & 26
- add class to handle version checks 
- update tests
## Why 
- so that the sdk can be used on versions of android lower than 26