### PR TITLE
US2168978: Reduce min sdk version to 21

### DIFF
--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -24,7 +24,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 35
         versionCode 1
         versionName version

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId "com.worldpay.access.checkout.sample"
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
### What

- Reduce `minSdkVersion` to 21

### Why

- The latest changes introduced have reduced the requirements on the `minSdkVersion` required to be able to support for android API levels