### PR TITLE
Us2229776 remove lifecycle owner

### DIFF
--- a/access-checkout/src/androidTest/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserIntegrationTest.kt
+++ b/access-checkout/src/androidTest/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserIntegrationTest.kt
@@ -52,6 +52,8 @@ class AccessCheckoutValidationInitialiserIntegrationTest {
     private val baseUrl = "https://localhost:${wireMockPort}"
     private val checkoutId = "checkout id"
 
+    private val lifecycleOwner = TestLifecycleOwner()
+
     @Before
     fun setUp() {
         DiscoveryCache.results.clear()
@@ -70,7 +72,12 @@ class AccessCheckoutValidationInitialiserIntegrationTest {
         val expectedKey2InDiscoveryCache = "service:sessions,sessions:paymentsCvc"
         val expectedKey3InDiscoveryCache = "cardBinPublic:binDetails"
 
-        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, cardValidationConfig())
+        AccessCheckoutValidationInitialiser.initialise(
+            checkoutId,
+            baseUrl,
+            cardValidationConfig(),
+            lifecycleOwner
+        )
 
         await().atMost(timeout, SECONDS).until {
             DiscoveryCache.results.size == 3
@@ -85,7 +92,12 @@ class AccessCheckoutValidationInitialiserIntegrationTest {
         // we do not stub the service discovery responses to simulate a failure to discover services
         WireMock.removeAllMappings()
 
-        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, cardValidationConfig())
+        AccessCheckoutValidationInitialiser.initialise(
+            checkoutId,
+            baseUrl,
+            cardValidationConfig(),
+            lifecycleOwner
+        )
 
         await()
             // waits for 1 second (at which point the service discovery has already
@@ -104,7 +116,7 @@ class AccessCheckoutValidationInitialiserIntegrationTest {
             .pan(pan)
             .expiryDate(expiryDate)
             .cvc(cvc)
-            .validationListener(TestValidationListener()).lifecycleOwner(TestLifecycleOwner())
+            .validationListener(TestValidationListener())
             .build()
     }
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/AccessCheckoutClientBuilder.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/AccessCheckoutClientBuilder.kt
@@ -116,7 +116,8 @@ class AccessCheckoutClientBuilder {
             context!!,
             checkoutId!!,
             baseUrl!!,
-            accessCheckoutClientDisposer
+            accessCheckoutClientDisposer,
+            lifecycleOwner!!
         )
     }
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/AccessCheckoutClientImpl.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/AccessCheckoutClientImpl.kt
@@ -2,7 +2,7 @@ package com.worldpay.access.checkout.client
 
 import android.content.Context
 import android.content.Intent
-import com.worldpay.access.checkout.client.session.BaseUrlSanitiser.sanitise
+import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.client.session.model.CardDetails
 import com.worldpay.access.checkout.client.session.model.SessionType
 import com.worldpay.access.checkout.client.validation.AccessCheckoutValidationInitialiser
@@ -22,7 +22,8 @@ internal class AccessCheckoutClientImpl(
     private val context: Context,
     private val checkoutId: String,
     private val baseUrl: String,
-    private val accessCheckoutClientDisposer: AccessCheckoutClientDisposer
+    private val accessCheckoutClientDisposer: AccessCheckoutClientDisposer,
+    private val lifecycleOwner: LifecycleOwner,
 ) : AccessCheckoutClient {
 
     private val activityLifecycleObserver: ActivityLifecycleObserver =
@@ -40,7 +41,7 @@ internal class AccessCheckoutClientImpl(
     }
 
     override fun initialiseValidation(validationConfiguration: ValidationConfig) {
-        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, validationConfiguration)
+        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, validationConfiguration, lifecycleOwner)
     }
 
     override fun dispose() {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfig.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfig.kt
@@ -1,7 +1,6 @@
 package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
-import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 import com.worldpay.access.checkout.util.PropertyValidationUtil.validateNotNull
@@ -18,7 +17,6 @@ class CardValidationConfig private constructor(
     val cvc: EditText,
     val acceptedCardBrands: Array<String>,
     val validationListener: AccessCheckoutCardValidationListener,
-    val lifecycleOwner: LifecycleOwner,
     val enablePanFormatting: Boolean,
 ) : ValidationConfig {
 
@@ -33,7 +31,6 @@ class CardValidationConfig private constructor(
 
         private var acceptedCardBrands: Array<String> = emptyArray()
         private var validationListener: AccessCheckoutCardValidationListener? = null
-        private var lifecycleOwner: LifecycleOwner? = null
         private var enablePanFormatting: Boolean = false
 
         /**
@@ -88,16 +85,6 @@ class CardValidationConfig private constructor(
         }
 
         /**
-         * Sets the lifecycle owner of the application so that validation state can be handled during lifecycle changes
-         *
-         * @param[lifecycleOwner] [LifecycleOwner] that represents the lifecycle owner of the application
-         */
-        fun lifecycleOwner(lifecycleOwner: LifecycleOwner): Builder {
-            this.lifecycleOwner = lifecycleOwner
-            return this
-        }
-
-        /**
          * Enables the pan formatting on the view
          */
         fun enablePanFormatting(): Builder {
@@ -116,7 +103,6 @@ class CardValidationConfig private constructor(
             validateNotNull(expiryDate, "expiry date component")
             validateNotNull(cvc, "cvc component")
             validateNotNull(validationListener, "validation listener")
-            validateNotNull(lifecycleOwner, "lifecycle owner")
 
 
             return CardValidationConfig(
@@ -125,7 +111,6 @@ class CardValidationConfig private constructor(
                 cvc = cvc!!,
                 acceptedCardBrands = acceptedCardBrands,
                 validationListener = validationListener!!,
-                lifecycleOwner = lifecycleOwner!!,
                 enablePanFormatting = enablePanFormatting,
             )
         }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfig.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfig.kt
@@ -1,7 +1,6 @@
 package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
-import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCvcValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
@@ -16,7 +15,6 @@ import com.worldpay.access.checkout.util.PropertyValidationUtil.validateNotNull
 class CvcValidationConfig private constructor(
     val cvc: EditText,
     val validationListener: AccessCheckoutCvcValidationListener,
-    val lifecycleOwner: LifecycleOwner
 ) : ValidationConfig {
 
     /**
@@ -26,7 +24,6 @@ class CvcValidationConfig private constructor(
 
         private var cvc: EditText? = null
         private var validationListener: AccessCheckoutCvcValidationListener? = null
-        private var lifecycleOwner: LifecycleOwner? = null
 
         /**
          * Sets the cvc ui element to be validated
@@ -49,16 +46,6 @@ class CvcValidationConfig private constructor(
         }
 
         /**
-         * Sets the lifecycle owner of the application so that validation state can be handled during lifecycle changes
-         *
-         * @param[lifecycleOwner] [LifecycleOwner] that represents the lifecycle owner of the application
-         */
-        fun lifecycleOwner(lifecycleOwner: LifecycleOwner): Builder {
-            this.lifecycleOwner = lifecycleOwner
-            return this
-        }
-
-        /**
          * Builds the validation configuration by returning an instance of the [CvcValidationConfig]
          *
          * @return [CvcValidationConfig] implementation that can be used to initialise validation
@@ -67,12 +54,10 @@ class CvcValidationConfig private constructor(
         fun build(): CvcValidationConfig {
             validateNotNull(cvc, "cvc component")
             validateNotNull(validationListener, "validation listener")
-            validateNotNull(lifecycleOwner, "lifecycle owner")
 
             return CvcValidationConfig(
                 cvc = cvc!!,
                 validationListener = validationListener!!,
-                lifecycleOwner = lifecycleOwner!!
             )
         }
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/testutil/AbstractValidationIntegrationTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/testutil/AbstractValidationIntegrationTest.kt
@@ -91,7 +91,6 @@ open class AbstractValidationIntegrationTest : BaseCoroutineTest() {
             .cvc(cvc)
             .expiryDate(expiryDate)
             .validationListener(cardValidationListener)
-            .lifecycleOwner(lifecycleOwner)
 
         if (enablePanFormatting) {
             cardValidationConfig.enablePanFormatting()

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/AccessCheckoutValidationInitialiserTest.kt
@@ -44,14 +44,18 @@ class AccessCheckoutValidationInitialiserTest : AbstractValidationIntegrationTes
             .cvc(cvc)
             .acceptedCardBrands(acceptedCardBrands)
             .validationListener(cardValidationListener)
-            .lifecycleOwner(lifecycleOwner)
             .build()
 
         assertEquals(0, pan.filters.size)
         assertEquals(0, expiryDate.filters.size)
         assertEquals(0, cvc.filters.size)
 
-        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, config)
+        AccessCheckoutValidationInitialiser.initialise(
+            checkoutId,
+            baseUrl,
+            config,
+            lifecycleOwner
+        )
 
         assertNotNull(pan.filters.any { it is PanNumericFilter })
         assertNotNull(expiryDate.filters.any { it is ExpiryDateLengthFilter })
@@ -64,12 +68,16 @@ class AccessCheckoutValidationInitialiserTest : AbstractValidationIntegrationTes
             .cvc(cvc)
             .validationListener(cardValidationListener)
             .validationListener(cvcValidationListener)
-            .lifecycleOwner(lifecycleOwner)
             .build()
 
         assertEquals(0, cvc.filters.size)
 
-        AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, config)
+        AccessCheckoutValidationInitialiser.initialise(
+            checkoutId,
+            baseUrl,
+            config,
+            lifecycleOwner
+        )
 
         assertNotNull(cvc.filters.any { it is CvcLengthFilter })
     }

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfigBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CardValidationConfigBuilderTest.kt
@@ -1,15 +1,14 @@
 package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
-import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCardValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
-import kotlin.test.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.BDDMockito.given
 import org.mockito.kotlin.mock
+import kotlin.test.*
 
 class CardValidationConfigBuilderTest {
 
@@ -24,7 +23,6 @@ class CardValidationConfigBuilderTest {
     private val acceptedCardBrands =
         arrayOf("AMEX", "DINERS", "DISCOVER", "JCB", "MAESTRO", "MASTERCARD", "VISA")
     private val validationListener = mock<AccessCheckoutCardValidationListener>()
-    private val lifecycleOwner = mock<LifecycleOwner>()
 
     @Before
     fun setUp() {
@@ -41,7 +39,6 @@ class CardValidationConfigBuilderTest {
             .cvc(cvc)
             .acceptedCardBrands(acceptedCardBrands)
             .validationListener(validationListener)
-            .lifecycleOwner(lifecycleOwner)
             .build()
 
         assertNotNull(config)
@@ -60,7 +57,6 @@ class CardValidationConfigBuilderTest {
             .expiryDate(expiryDate)
             .cvc(cvc)
             .validationListener(validationListener)
-            .lifecycleOwner(lifecycleOwner)
             .build()
 
         assertNotNull(config)
@@ -79,7 +75,6 @@ class CardValidationConfigBuilderTest {
                 .cvc(cvc)
                 .acceptedCardBrands(acceptedCardBrands)
                 .validationListener(validationListener)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 
@@ -94,7 +89,6 @@ class CardValidationConfigBuilderTest {
                 .cvc(cvc)
                 .acceptedCardBrands(acceptedCardBrands)
                 .validationListener(validationListener)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 
@@ -109,7 +103,6 @@ class CardValidationConfigBuilderTest {
                 .expiryDate(expiryDate)
                 .acceptedCardBrands(acceptedCardBrands)
                 .validationListener(validationListener)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 
@@ -124,26 +117,10 @@ class CardValidationConfigBuilderTest {
                 .expiryDate(expiryDate)
                 .cvc(cvc)
                 .acceptedCardBrands(acceptedCardBrands)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 
         assertEquals("Expected validation listener to be provided but was not", exception.message)
-    }
-
-    @Test
-    fun `should throw exception where lifecycle owner is not provided`() {
-        val exception = assertFailsWith<AccessCheckoutException> {
-            CardValidationConfig.Builder()
-                .pan(pan)
-                .expiryDate(expiryDate)
-                .cvc(cvc)
-                .acceptedCardBrands(acceptedCardBrands)
-                .validationListener(validationListener)
-                .build()
-        }
-
-        assertEquals("Expected lifecycle owner to be provided but was not", exception.message)
     }
 
     @Test
@@ -154,7 +131,6 @@ class CardValidationConfigBuilderTest {
             .cvc(cvc)
             .acceptedCardBrands(acceptedCardBrands)
             .validationListener(validationListener)
-            .lifecycleOwner(lifecycleOwner)
             .enablePanFormatting()
             .build()
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfigBuilderTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/client/validation/config/CvcValidationConfigBuilderTest.kt
@@ -1,17 +1,16 @@
 package com.worldpay.access.checkout.client.validation.config
 
 import android.widget.EditText
-import androidx.lifecycle.LifecycleOwner
 import com.worldpay.access.checkout.client.api.exception.AccessCheckoutException
 import com.worldpay.access.checkout.client.validation.listener.AccessCheckoutCvcValidationListener
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.BDDMockito.given
 import org.mockito.kotlin.mock
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class CvcValidationConfigBuilderTest {
 
@@ -19,7 +18,6 @@ class CvcValidationConfigBuilderTest {
     private val cvcInternalEditText = mock<EditText>()
 
     private val validationListener = mock<AccessCheckoutCvcValidationListener>()
-    private val lifecycleOwner = mock<LifecycleOwner>()
 
     @Before
     fun setUp() {
@@ -31,7 +29,6 @@ class CvcValidationConfigBuilderTest {
         val config = CvcValidationConfig.Builder()
             .cvc(cvc)
             .validationListener(validationListener)
-            .lifecycleOwner(lifecycleOwner)
             .build()
 
         assertNotNull(config)
@@ -44,7 +41,6 @@ class CvcValidationConfigBuilderTest {
         val exception = assertFailsWith<AccessCheckoutException> {
             CvcValidationConfig.Builder()
                 .validationListener(validationListener)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 
@@ -52,23 +48,10 @@ class CvcValidationConfigBuilderTest {
     }
 
     @Test
-    fun `should throw exception where lifecycle owner is not provided`() {
-        val exception = assertFailsWith<AccessCheckoutException> {
-            CvcValidationConfig.Builder()
-                .cvc(cvc)
-                .validationListener(validationListener)
-                .build()
-        }
-
-        assertEquals("Expected lifecycle owner to be provided but was not", exception.message)
-    }
-
-    @Test
     fun `should throw exception where validation listener is not provided`() {
         val exception = assertFailsWith<AccessCheckoutException> {
             CvcValidationConfig.Builder()
                 .cvc(cvc)
-                .lifecycleOwner(lifecycleOwner)
                 .build()
         }
 

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/AccessCheckoutClientImplTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/session/handlers/AccessCheckoutClientImplTest.kt
@@ -70,7 +70,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
         assertNotNull(accessCheckoutClient)
     }
@@ -89,7 +90,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
 
         val cardDetails = CardDetails.Builder()
@@ -119,7 +121,8 @@ class AccessCheckoutClientImplTest {
             contextMock,
             checkoutId,
             baseUrl,
-            accessCheckoutClientDisposer
+            accessCheckoutClientDisposer,
+            lifecycleOwnerMock
         )
 
         verify(activityLifecycleObserverInitialiser).initialise()
@@ -147,7 +150,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
 
         accessCheckoutClient.generateSessions(cardDetails, tokenRequests)
@@ -175,7 +179,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
 
         accessCheckoutClient.generateSessions(cardDetails, tokenRequests)
@@ -208,7 +213,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
 
         accessCheckoutClient.generateSessions(cardDetails, tokenRequests)
@@ -238,7 +244,8 @@ class AccessCheckoutClientImplTest {
                 contextMock,
                 checkoutId,
                 baseUrl,
-                accessCheckoutClientDisposer
+                accessCheckoutClientDisposer,
+                lifecycleOwnerMock
             )
 
         accessCheckoutClient.generateSessions(cardDetails, emptyList())
@@ -261,7 +268,8 @@ class AccessCheckoutClientImplTest {
             contextMock,
             checkoutId,
             baseUrl,
-            accessCheckoutClientDisposer
+            accessCheckoutClientDisposer,
+            lifecycleOwnerMock
         )
 
         accessCheckoutClient.disposeInternal()
@@ -282,7 +290,8 @@ class AccessCheckoutClientImplTest {
             contextMock,
             checkoutId,
             baseUrl,
-            accessCheckoutClientDisposer
+            accessCheckoutClientDisposer,
+            lifecycleOwnerMock
         )
 
         accessCheckoutClient.dispose()
@@ -302,14 +311,15 @@ class AccessCheckoutClientImplTest {
             contextMock,
             checkoutId,
             baseUrl,
-            accessCheckoutClientDisposer
+            accessCheckoutClientDisposer,
+            lifecycleOwnerMock
         )
 
         accessCheckoutClient.initialiseValidation(mockConfig)
 
         mockValidation.use {
             it.verify {
-                AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, mockConfig)
+                AccessCheckoutValidationInitialiser.initialise(checkoutId, baseUrl, mockConfig, lifecycleOwnerMock)
             }
         }
     }

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CardFlowFragment.kt
@@ -120,7 +120,6 @@ class CardFlowFragment : Fragment() {
             .expiryDate(expiryText)
             .cvc(cvcText)
             .validationListener(cardValidationListener)
-            .lifecycleOwner(this)
             .enablePanFormatting()
             .build()
 

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CvcFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/CvcFlowFragment.kt
@@ -80,7 +80,6 @@ class CvcFlowFragment : Fragment() {
         val cvcValidationConfig = CvcValidationConfig.Builder()
             .cvc(cvcText)
             .validationListener(cvcValidationListener)
-            .lifecycleOwner(this)
             .build()
 
         accessCheckoutClient.initialiseValidation(cvcValidationConfig)

--- a/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/RestrictedCardFlowFragment.kt
+++ b/demo-app/src/main/java/com/worldpay/access/checkout/sample/ui/RestrictedCardFlowFragment.kt
@@ -74,7 +74,6 @@ class RestrictedCardFlowFragment : Fragment() {
             .cvc(cvcText)
             .acceptedCardBrands(arrayOf("visa", "mastercard", "amex"))
             .validationListener(cardValidationListener)
-            .lifecycleOwner(this)
             .build()
 
         accessCheckoutClient.initialiseValidation(cardValidationConfig)


### PR DESCRIPTION
## What
- Remove lifecycle owner argument from card and cvc validation config 
## How
- remove `lifecycleOwner` from validation configs
- update classes and test accordingly
## Why
- so that redundant code is removed
- so that the `lifecycleOwner` provided to the client can be used downstream