### PR TITLE
US2239276: update min Android SDK version to 24

### DIFF
--- a/access-checkout/gradle/android.gradle
+++ b/access-checkout/gradle/android.gradle
@@ -1,5 +1,5 @@
 android {
-    compileSdk 35
+    compileSdk = 35
 
     namespace = "com.worldpay.access.checkout"
 
@@ -24,7 +24,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 35
         versionCode 1
         versionName version

--- a/demo-app/build.gradle
+++ b/demo-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdk 35
+    compileSdk = 35
 
     namespace = "com.worldpay.access.checkout.sample"
 
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId "com.worldpay.access.checkout.sample"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
### What
- update min Android version to 24

### Why
- before Android 24, the list of CAs installed on devices may vary from device to device. As a consequence, SSL handshakes may fail on some devices running versions below API level 24