### PR TITLE
US2239299: Added support for keyboard navigation

### DIFF
--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -260,6 +260,38 @@ class AccessCheckoutEditText internal constructor(
     }
 
     /**
+     * Returns the next focus forward id for this component.
+     *
+     * @return the next focus forward id
+     */
+    override fun getNextFocusForwardId() = this.editText!!.nextFocusForwardId
+
+    /**
+     * Sets the next focus forward id for this component.
+     *
+     * @param nextFocusForwardId id of the next view to focus when navigating forward
+     */
+    override fun setNextFocusForwardId(nextFocusForwardId: Int) {
+        this.editText!!.nextFocusForwardId = nextFocusForwardId
+    }
+
+    /**
+     * Returns the next focus up id for this component.
+     *
+     * @return the next focus up id
+     */
+    override fun getNextFocusUpId() = this.editText!!.nextFocusUpId
+
+    /**
+     * Sets the next focus up id for this component.
+     *
+     * @param nextFocusUpId id of the next view to focus when navigating up
+     */
+    override fun setNextFocusUpId(nextFocusUpId: Int) {
+        this.editText!!.nextFocusUpId = nextFocusUpId
+    }
+
+    /**
      * Returns the next focus down id for this component.
      *
      * @return the next focus down id
@@ -276,19 +308,35 @@ class AccessCheckoutEditText internal constructor(
     }
 
     /**
-     * Returns the next focus forward id for this component.
+     * Returns the next focus left id for this component.
      *
-     * @return the next focus forward id
+     * @return the next focus left id
      */
-    override fun getNextFocusForwardId() = this.editText!!.nextFocusForwardId
+    override fun getNextFocusLeftId() = this.editText!!.nextFocusLeftId
 
     /**
-     * Sets the next focus forward id for this component.
+     * Sets the next focus left id for this component.
      *
-     * @param nextFocusForwardId id of the next view to focus when navigating forward
+     * @param nextFocusLeftId id of the next view to focus when navigating left
      */
-    override fun setNextFocusForwardId(nextFocusForwardId: Int) {
-        this.editText!!.nextFocusForwardId = nextFocusForwardId
+    override fun setNextFocusLeftId(nextFocusLeftId: Int) {
+        this.editText!!.nextFocusLeftId = nextFocusLeftId
+    }
+
+    /**
+     * Returns the next focus right id for this component.
+     *
+     * @return the next focus right id
+     */
+    override fun getNextFocusRightId() = this.editText!!.nextFocusRightId
+
+    /**
+     * Sets the next focus right id for this component.
+     *
+     * @param nextFocusRightId id of the next view to focus when navigating right
+     */
+    override fun setNextFocusRightId(nextFocusRightId: Int) {
+        this.editText!!.nextFocusRightId = nextFocusRightId
     }
 
 

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -2,6 +2,7 @@ package com.worldpay.access.checkout.ui
 
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Build
@@ -340,7 +341,6 @@ class AccessCheckoutEditText internal constructor(
         if (BuildVersionProviderHolder.instance.isAtLeastO()) editText?.setAutofillHints(*hints)
     }
 
-
     @RequiresApi(Build.VERSION_CODES.O)
     override fun getAutofillHints(): Array<String>? {
         return if (BuildVersionProviderHolder.instance.isAtLeastO()) {
@@ -348,6 +348,17 @@ class AccessCheckoutEditText internal constructor(
         } else {
             null
         }
+    }
+
+    override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
+        return editText?.requestFocus(direction, previouslyFocusedRect) ?: super.requestFocus(
+            direction,
+            previouslyFocusedRect
+        )
+    }
+
+    override fun focusSearch(direction: Int): View? {
+        return editText?.focusSearch(direction) ?: super.focusSearch(direction)
     }
 
     public override fun onSaveInstanceState(): Parcelable? {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AccessCheckoutEditText.kt
@@ -260,6 +260,39 @@ class AccessCheckoutEditText internal constructor(
     }
 
     /**
+     * Returns the next focus down id for this component.
+     *
+     * @return the next focus down id
+     */
+    override fun getNextFocusDownId() = this.editText!!.nextFocusDownId
+
+    /**
+     * Sets the next focus down id for this component.
+     *
+     * @param nextFocusDownId id of the next view to focus when navigating down
+     */
+    override fun setNextFocusDownId(nextFocusDownId: Int) {
+        this.editText!!.nextFocusDownId = nextFocusDownId
+    }
+
+    /**
+     * Returns the next focus forward id for this component.
+     *
+     * @return the next focus forward id
+     */
+    override fun getNextFocusForwardId() = this.editText!!.nextFocusForwardId
+
+    /**
+     * Sets the next focus forward id for this component.
+     *
+     * @param nextFocusForwardId id of the next view to focus when navigating forward
+     */
+    override fun setNextFocusForwardId(nextFocusForwardId: Int) {
+        this.editText!!.nextFocusForwardId = nextFocusForwardId
+    }
+
+
+    /**
      * Methods
      */
 
@@ -351,14 +384,11 @@ class AccessCheckoutEditText internal constructor(
     }
 
     override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
-        return editText?.requestFocus(direction, previouslyFocusedRect) ?: super.requestFocus(
-            direction,
-            previouslyFocusedRect
-        )
+        return editText!!.requestFocus(direction, previouslyFocusedRect)
     }
 
     override fun focusSearch(direction: Int): View? {
-        return editText?.focusSearch(direction) ?: super.focusSearch(direction)
+        return editText!!.focusSearch(direction)
     }
 
     public override fun onSaveInstanceState(): Parcelable? {

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
@@ -35,6 +35,10 @@ internal class AttributeValues(
         if (BuildVersionProviderHolder.instance.isAtLeastO()) setFontAttribute(editText)
 
         setEnabledAttribute(editText)
+
+        setNextFocusDown(editText)
+
+        setNextFocusForward(editText)
     }
 
     private fun setPaddingAttribute(editText: EditText) {
@@ -127,6 +131,16 @@ internal class AttributeValues(
         editText.isEnabled = enabled
     }
 
+    private fun setNextFocusDown(editText: EditText) {
+        val nextFocusDown = getNextFocusDown()
+        nextFocusDown.takeIf { it != 0 }?.let { editText.nextFocusDownId = nextFocusDown }
+    }
+
+    private fun setNextFocusForward(editText: EditText) {
+        val nextFocusForward = getNextFocusForward()
+        nextFocusForward.takeIf { it != 0 }?.let { editText.nextFocusForwardId = nextFocusForward }
+    }
+
     private fun getPaddingBottomAttribute(): Int? =
         getDimensionAttribute(R.styleable.AccessCheckoutEditText_android_paddingBottom)
 
@@ -185,4 +199,12 @@ internal class AttributeValues(
 
     private fun getEnabledAttribute() =
         styledAttributes.getBoolean(R.styleable.AccessCheckoutEditText_android_enabled, true)
+
+    private fun getNextFocusDown() =
+        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusDown, 0)
+
+    private fun getNextFocusForward() = styledAttributes.getResourceId(
+        R.styleable.AccessCheckoutEditText_android_nextFocusForward,
+        0
+    )
 }

--- a/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
+++ b/access-checkout/src/main/java/com/worldpay/access/checkout/ui/AttributeValues.kt
@@ -36,9 +36,15 @@ internal class AttributeValues(
 
         setEnabledAttribute(editText)
 
+        setNextFocusForward(editText)
+        
+        setNextFocusUp(editText)
+
         setNextFocusDown(editText)
 
-        setNextFocusForward(editText)
+        setNextFocusLeft(editText)
+
+        setNextFocusRight(editText)
     }
 
     private fun setPaddingAttribute(editText: EditText) {
@@ -131,14 +137,29 @@ internal class AttributeValues(
         editText.isEnabled = enabled
     }
 
+    private fun setNextFocusForward(editText: EditText) {
+        val nextFocusForward = getNextFocusForward()
+        nextFocusForward.takeIf { it != 0 }?.let { editText.nextFocusForwardId = nextFocusForward }
+    }
+
+    private fun setNextFocusUp(editText: EditText) {
+        val nextFocusUp = getNextFocusUp()
+        nextFocusUp.takeIf { it != 0 }?.let { editText.nextFocusUpId = nextFocusUp }
+    }
+
     private fun setNextFocusDown(editText: EditText) {
         val nextFocusDown = getNextFocusDown()
         nextFocusDown.takeIf { it != 0 }?.let { editText.nextFocusDownId = nextFocusDown }
     }
 
-    private fun setNextFocusForward(editText: EditText) {
-        val nextFocusForward = getNextFocusForward()
-        nextFocusForward.takeIf { it != 0 }?.let { editText.nextFocusForwardId = nextFocusForward }
+    private fun setNextFocusLeft(editText: EditText) {
+        val nextFocusLeft = getNextFocusLeft()
+        nextFocusLeft.takeIf { it != 0 }?.let { editText.nextFocusLeftId = nextFocusLeft }
+    }
+
+    private fun setNextFocusRight(editText: EditText) {
+        val nextFocusRight = getNextFocusRight()
+        nextFocusRight.takeIf { it != 0 }?.let { editText.nextFocusRightId = nextFocusRight }
     }
 
     private fun getPaddingBottomAttribute(): Int? =
@@ -200,11 +221,20 @@ internal class AttributeValues(
     private fun getEnabledAttribute() =
         styledAttributes.getBoolean(R.styleable.AccessCheckoutEditText_android_enabled, true)
 
-    private fun getNextFocusDown() =
-        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusDown, 0)
-
     private fun getNextFocusForward() = styledAttributes.getResourceId(
         R.styleable.AccessCheckoutEditText_android_nextFocusForward,
         0
     )
+    private fun getNextFocusUp() =
+        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusUp, 0)
+
+    private fun getNextFocusDown() =
+        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusDown, 0)
+
+    private fun getNextFocusLeft() =
+        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusLeft, 0)
+
+    private fun getNextFocusRight() =
+        styledAttributes.getResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusRight, 0)
+
 }

--- a/access-checkout/src/main/res/values/attr.xml
+++ b/access-checkout/src/main/res/values/attr.xml
@@ -18,5 +18,7 @@
         <attr name="android:font"/>
         <attr name="android:background"/>
         <attr name="android:enabled"/>
+        <attr name="android:nextFocusDown"/>
+        <attr name="android:nextFocusForward"/>
     </declare-styleable>
 </resources>

--- a/access-checkout/src/main/res/values/attr.xml
+++ b/access-checkout/src/main/res/values/attr.xml
@@ -18,7 +18,10 @@
         <attr name="android:font"/>
         <attr name="android:background"/>
         <attr name="android:enabled"/>
-        <attr name="android:nextFocusDown"/>
         <attr name="android:nextFocusForward"/>
+        <attr name="android:nextFocusUp"/>
+        <attr name="android:nextFocusDown"/>
+        <attr name="android:nextFocusLeft"/>
+        <attr name="android:nextFocusRight"/>
     </declare-styleable>
 </resources>

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -474,6 +474,28 @@ class AccessCheckoutEditTextTest {
     }
 
     @Test
+    fun `should set nextFocusForward from attribute set`() {
+        val viewId = 123
+
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusForward, viewId)
+
+        AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
+
+        verify(editTextMock).nextFocusForwardId = viewId
+    }
+
+    @Test
+    fun `should set nextFocusUp from attribute set`() {
+        val viewId = 123
+
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusUp, viewId)
+
+        AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
+
+        verify(editTextMock).nextFocusUpId = viewId
+    }
+
+    @Test
     fun `should set nextFocusDown from attribute set`() {
         val viewId = 123
 
@@ -485,14 +507,25 @@ class AccessCheckoutEditTextTest {
     }
 
     @Test
-    fun `should set nextFocusForward from attribute set`() {
+    fun `should set nextFocusLeft from attribute set`() {
         val viewId = 123
 
-        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusForward, viewId)
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusLeft, viewId)
 
         AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
 
-        verify(editTextMock).nextFocusForwardId = viewId
+        verify(editTextMock).nextFocusLeftId = viewId
+    }
+
+    @Test
+    fun `should set nextFocusRight from attribute set`() {
+        val viewId = 123
+
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusRight, viewId)
+
+        AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
+
+        verify(editTextMock).nextFocusRightId = viewId
     }
 
     /**
@@ -738,6 +771,34 @@ class AccessCheckoutEditTextTest {
     }
 
     @Test
+    fun `nextFocusForwardId getter should return EditText nextFocusForwardId`() {
+        given(editTextMock.nextFocusForwardId).willReturn(123)
+
+        assertEquals(123, accessCheckoutEditText.nextFocusForwardId)
+    }
+
+    @Test
+    fun `nextFocusForwardId setter should set EditText nextFocusForwardId`() {
+        accessCheckoutEditText.nextFocusForwardId = 123
+
+        verify(editTextMock).nextFocusForwardId = 123
+    }
+
+    @Test
+    fun `nextFocusUpId getter should return EditText nextFocusUpId`() {
+        given(editTextMock.nextFocusUpId).willReturn(123)
+
+        assertEquals(123, accessCheckoutEditText.nextFocusUpId)
+    }
+
+    @Test
+    fun `nextFocusUpId setter should set EditText nextFocusUpId`() {
+        accessCheckoutEditText.nextFocusUpId = 123
+
+        verify(editTextMock).nextFocusUpId = 123
+    }
+
+    @Test
     fun `nextFocusDownId getter should return EditText nextFocusDownId`() {
         given(editTextMock.nextFocusDownId).willReturn(123)
 
@@ -752,17 +813,31 @@ class AccessCheckoutEditTextTest {
     }
 
     @Test
-    fun `nextFocusForwardId getter should return EditText nextFocusForwardId`() {
-        given(editTextMock.nextFocusForwardId).willReturn(123)
+    fun `nextFocusLeftId getter should return EditText nextFocusLeftId`() {
+        given(editTextMock.nextFocusLeftId).willReturn(123)
 
-        assertEquals(123, accessCheckoutEditText.nextFocusForwardId)
+        assertEquals(123, accessCheckoutEditText.nextFocusLeftId)
     }
 
     @Test
-    fun `nextFocusForwardId setter should set EditText nextFocusForwardId`() {
-        accessCheckoutEditText.nextFocusForwardId = 123
+    fun `nextFocusLeftId setter should set EditText nextFocusLeftId`() {
+        accessCheckoutEditText.nextFocusLeftId = 123
 
-        verify(editTextMock).nextFocusForwardId = 123
+        verify(editTextMock).nextFocusLeftId = 123
+    }
+
+    @Test
+    fun `nextFocusRightId getter should return EditText nextFocusRightId`() {
+        given(editTextMock.nextFocusRightId).willReturn(123)
+
+        assertEquals(123, accessCheckoutEditText.nextFocusRightId)
+    }
+
+    @Test
+    fun `nextFocusRightId setter should set EditText nextFocusRightId`() {
+        accessCheckoutEditText.nextFocusRightId = 123
+
+        verify(editTextMock).nextFocusRightId = 123
     }
 
     /**

--- a/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
+++ b/access-checkout/src/test/java/com/worldpay/access/checkout/ui/AccessCheckoutEditTextTest.kt
@@ -5,6 +5,7 @@ import android.content.res.TypedArray
 import android.graphics.Color
 import android.graphics.Color.GREEN
 import android.graphics.Color.RED
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
@@ -30,8 +31,12 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyFloat
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.never
-import org.mockito.kotlin.*
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -468,6 +473,28 @@ class AccessCheckoutEditTextTest {
         verify(editTextMock).background = drawable
     }
 
+    @Test
+    fun `should set nextFocusDown from attribute set`() {
+        val viewId = 123
+
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusDown, viewId)
+
+        AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
+
+        verify(editTextMock).nextFocusDownId = viewId
+    }
+
+    @Test
+    fun `should set nextFocusForward from attribute set`() {
+        val viewId = 123
+
+        mockResourceId(R.styleable.AccessCheckoutEditText_android_nextFocusForward, viewId)
+
+        AccessCheckoutEditText(contextMock, attributeSetMock, 0, editTextMock)
+
+        verify(editTextMock).nextFocusForwardId = viewId
+    }
+
     /**
      * Properties tests
      */
@@ -710,6 +737,34 @@ class AccessCheckoutEditTextTest {
         verify(editTextMock).isEnabled = true
     }
 
+    @Test
+    fun `nextFocusDownId getter should return EditText nextFocusDownId`() {
+        given(editTextMock.nextFocusDownId).willReturn(123)
+
+        assertEquals(123, accessCheckoutEditText.nextFocusDownId)
+    }
+
+    @Test
+    fun `nextFocusDownId setter should set EditText nextFocusDownId`() {
+        accessCheckoutEditText.nextFocusDownId = 123
+
+        verify(editTextMock).nextFocusDownId = 123
+    }
+
+    @Test
+    fun `nextFocusForwardId getter should return EditText nextFocusForwardId`() {
+        given(editTextMock.nextFocusForwardId).willReturn(123)
+
+        assertEquals(123, accessCheckoutEditText.nextFocusForwardId)
+    }
+
+    @Test
+    fun `nextFocusForwardId setter should set EditText nextFocusForwardId`() {
+        accessCheckoutEditText.nextFocusForwardId = 123
+
+        verify(editTextMock).nextFocusForwardId = 123
+    }
+
     /**
     Methods tests
      */
@@ -855,6 +910,22 @@ class AccessCheckoutEditTextTest {
         verify(editTextMock).setBackgroundResource(123)
     }
 
+    @Test
+    fun `requestFocus should call EditText requestFocus()`() {
+        val mockRect = mock<Rect>()
+
+        accessCheckoutEditText.requestFocus(View.FOCUS_DOWN, mockRect)
+
+        verify(editTextMock).requestFocus(View.FOCUS_DOWN, mockRect)
+    }
+
+    @Test
+    fun `focusSearch should call EditText focusSearch()`() {
+        accessCheckoutEditText.focusSearch(View.FOCUS_DOWN)
+
+        verify(editTextMock).focusSearch(View.FOCUS_DOWN)
+    }
+
     private fun assertParentPaddingValue(accessCheckoutEditText: AccessCheckoutEditText) {
         assertEquals(accessCheckoutEditText.paddingLeft, 0)
         assertEquals(accessCheckoutEditText.paddingTop, 0)
@@ -902,4 +973,9 @@ class AccessCheckoutEditTextTest {
         // Value -1F, as per production code, is a default value to indicate attribute is not set
         mockAttributeValue(attributeId, -1F)
     }
+
+    private fun mockResourceId(attributeId: Int, value: Int) {
+        given(typedArrayMock.getResourceId(eq(attributeId), anyInt())).willReturn(value)
+    }
+
 }

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/card/standard/testutil/CardFragmentTestUtils.kt
@@ -1,5 +1,6 @@
 package com.worldpay.access.checkout.sample.card.standard.testutil
 
+import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.ImageView
 import androidx.appcompat.widget.SwitchCompat
@@ -11,11 +12,12 @@ import androidx.test.rule.ActivityTestRule
 import com.worldpay.access.checkout.sample.MainActivity
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.sample.testutil.AbstractFragmentTestUtils
+import com.worldpay.access.checkout.sample.testutil.UITestUtils.isKeyboardOpened
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.retrieveEnteredText
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.uiObjectWithId
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 import kotlin.test.assertEquals
-import kotlin.test.assertSame
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : AbstractFragmentTestUtils(activityRule) {
@@ -39,6 +41,7 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
         cardDetailsAre(pan = "", cvc = "", expiryDate = "")
         hasNoBrand()
         paymentsCvcSessionCheckedState(checked = false)
+        verifyKeyboardImeOptions()
         return this
     }
 
@@ -215,6 +218,39 @@ class CardFragmentTestUtils(activityRule: ActivityTestRule<MainActivity>) : Abst
 
     fun hasAutofillHints(id: Int, expectedAutofillHint: Array<String>): CardFragmentTestUtils {
         wait{ assertTrue { expectedAutofillHint contentEquals field(id).autofillHints}}
+        return this
+    }
+
+    fun verifyKeyboardImeOptions(): CardFragmentTestUtils {
+        wait { assertEquals(EditorInfo.IME_ACTION_NEXT, panInput().imeOptions) }
+        wait { assertEquals(EditorInfo.IME_ACTION_NEXT, expiryDateInput().imeOptions) }
+        wait {
+            val imeOptions = EditorInfo.IME_ACTION_DONE + EditorInfo.IME_FLAG_NO_FULLSCREEN
+            assertEquals(imeOptions, cvcInput().imeOptions)
+        }
+        return this
+    }
+
+    fun hasFocus(input: Input): CardFragmentTestUtils {
+        when (input) {
+            Input.PAN -> wait { assertTrue(panInput().hasFocus()) }
+            Input.EXPIRY_DATE -> wait { assertTrue(expiryDateInput().hasFocus()) }
+            Input.CVC -> wait { assertTrue(cvcInput().hasFocus()) }
+        }
+        return this
+    }
+
+    fun enterCardDetail(input: Input, value: String, hideKeyboard: Boolean): CardFragmentTestUtils {
+        when (input) {
+            Input.PAN -> enterText(panInput(), value, hideKeyboard)
+            Input.EXPIRY_DATE -> enterText(expiryDateInput(), value, hideKeyboard)
+            Input.CVC -> enterText(cvcInput(), value, hideKeyboard)
+        }
+        return this
+    }
+
+    fun keyboardIsClosed(): CardFragmentTestUtils {
+        wait(10000) { assertFalse(isKeyboardOpened()) }
         return this
     }
 }

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/AbstractFragmentTestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/AbstractFragmentTestUtils.kt
@@ -57,7 +57,11 @@ abstract class AbstractFragmentTestUtils(private val activityRule: ActivityTestR
         }
     }
 
-    protected fun enterText(accessCheckoutEditText: AccessCheckoutEditText, text: String) {
+    protected fun enterText(
+        accessCheckoutEditText: AccessCheckoutEditText,
+        text: String,
+        hideKeyboard: Boolean = true
+    ) {
         wait { assertTrue("${accessCheckoutEditText.id} - visibility state") { accessCheckoutEditText.isVisible } }
         wait { assertTrue("${accessCheckoutEditText.id} - enabled state") { accessCheckoutEditText.isEnabled } }
         wait { assertEquals(1.0f, accessCheckoutEditText.alpha, "${accessCheckoutEditText.id} - alpha state") }
@@ -66,8 +70,10 @@ abstract class AbstractFragmentTestUtils(private val activityRule: ActivityTestR
         editTextUI.click()
         activityRule.activity.runOnUiThread { accessCheckoutEditText.setText(text) }
 
-        val im = activity().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        im.hideSoftInputFromWindow(accessCheckoutEditText.windowToken, 0)
+        if (hideKeyboard) {
+            val im = activity().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+            im.hideSoftInputFromWindow(accessCheckoutEditText.windowToken, 0)
+        }
     }
 
     protected fun clearText(accessCheckoutEditText: AccessCheckoutEditText) {

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/UITestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/UITestUtils.kt
@@ -15,7 +15,8 @@ import androidx.test.espresso.contrib.DrawerMatchers.isOpen
 import androidx.test.espresso.contrib.NavigationViewActions
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice.getInstance
@@ -24,8 +25,8 @@ import androidx.test.uiautomator.UiSelector
 import com.worldpay.access.checkout.sample.MainActivity
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
-import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility.await
+import java.util.concurrent.TimeUnit
 
 object UITestUtils {
 
@@ -35,7 +36,7 @@ object UITestUtils {
         return getInstance(getInstrumentation()).findObject(selector)
     }
 
-    private fun isKeyboardOpened(): Boolean {
+    fun isKeyboardOpened(): Boolean {
         for (window in getInstrumentation().uiAutomation.windows) {
             if (window.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD) {
                 return true
@@ -161,6 +162,14 @@ object UITestUtils {
 
     fun onCardPanView(): ViewInteraction {
         return onView(ViewMatchers.withParent(withId(R.id.card_flow_text_pan)))
+    }
+
+    fun onExpiryDateView(): ViewInteraction {
+        return onView(ViewMatchers.withParent(withId(R.id.card_flow_expiry_date)))
+    }
+
+    fun onCvcView(): ViewInteraction {
+        return onView(ViewMatchers.withParent(withId(R.id.card_flow_text_cvc)))
     }
 
     fun onCvcOnlyCvcView(): ViewInteraction {

--- a/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/UITestUtils.kt
+++ b/demo-app/src/androidTest/java/com/worldpay/access/checkout/sample/testutil/UITestUtils.kt
@@ -175,4 +175,10 @@ object UITestUtils {
     fun onCvcOnlyCvcView(): ViewInteraction {
         return onView(ViewMatchers.withParent(withId(R.id.cvc_flow_text_cvc)))
     }
+
+    fun repeatAction(times: Int, action: () -> Unit) {
+        for (i in 1..times) {
+            action()
+        }
+    }
 }

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
@@ -1,15 +1,20 @@
 package com.worldpay.access.checkout.sample.card.standard
 
+import android.view.KeyEvent
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
+import androidx.test.espresso.action.ViewActions.pressKey
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.sample.card.standard.testutil.AbstractCardFragmentTest
 import com.worldpay.access.checkout.sample.card.standard.testutil.CardBrand.VISA
-import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.*
+import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.CVC
+import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.EXPIRY_DATE
+import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.PAN
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.onCardPanView
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.onCvcView
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.onExpiryDateView
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.reopenApp
+import com.worldpay.access.checkout.sample.testutil.UITestUtils.repeatAction
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -34,7 +39,8 @@ class CardFragmentTest : AbstractCardFragmentTest() {
             .enabledStateIs(submitButton = true)
     }
 
-    @Test fun shouldHaveCorrectAutofillHints() {
+    @Test
+    fun shouldHaveCorrectAutofillHints() {
         cardFragmentTestUtils
             .isInInitialState()
             .hasAutofillHints(R.id.card_flow_text_pan, arrayOf("creditCardNumber"))
@@ -43,7 +49,7 @@ class CardFragmentTest : AbstractCardFragmentTest() {
     }
 
     @Test
-    fun shouldMoveFocusToNextField() {
+    fun shouldMoveFocusToNextFieldUsingActionButton() {
         cardFragmentTestUtils
             .isInInitialState()
             .enterCardDetail(PAN, "4111111111111111", false)
@@ -66,7 +72,7 @@ class CardFragmentTest : AbstractCardFragmentTest() {
     }
 
     @Test
-    fun shouldMoveFocusToNextFieldWithoutEnteringDetails() {
+    fun shouldMoveFocusToNextFieldWithoutEnteringDetailsUsingActionButton() {
         cardFragmentTestUtils
             .isInInitialState()
             .hasFocus(PAN)
@@ -87,7 +93,7 @@ class CardFragmentTest : AbstractCardFragmentTest() {
     }
 
     @Test
-    fun shouldMoveFocusToNextFieldWhenPartialDetailsAreEntered() {
+    fun shouldMoveFocusToNextFieldWhenPartialDetailsAreEnteredUsingActionButton() {
         // enter partial details in PAN field
         cardFragmentTestUtils
             .isInInitialState()
@@ -119,6 +125,101 @@ class CardFragmentTest : AbstractCardFragmentTest() {
         onCvcView().perform(pressImeActionButton())
 
         cardFragmentTestUtils.keyboardIsClosed()
+    }
+
+    @Test
+    fun shouldMoveFocusToNextFieldWithoutEnteringDetailsUsingDirectionPad() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasFocus(PAN)
+
+        onCardPanView().perform(pressKey(KeyEvent.KEYCODE_DPAD_DOWN))
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+
+        onExpiryDateView().perform(pressKey(KeyEvent.KEYCODE_DPAD_RIGHT))
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+
+        onCvcView().perform(pressKey(KeyEvent.KEYCODE_DPAD_UP))
+
+        cardFragmentTestUtils
+            .hasFocus(PAN)
+
+        onCardPanView().perform(pressKey(KeyEvent.KEYCODE_DPAD_RIGHT))
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+
+        onExpiryDateView().perform(pressKey(KeyEvent.KEYCODE_DPAD_DOWN))
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+
+        onCvcView().perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+    }
+
+    @Test
+    fun shouldMoveFocusToPreviousFieldWhenCaretIsAtTheStartUsingDirectionPad() {
+        val cvc = "4111"
+        cardFragmentTestUtils
+            .isInInitialState()
+            .enterCardDetail(CVC, cvc, false)
+
+        val count = cvc.length + 1 // move cursor to the start and one more to attempt to move focus
+
+        repeatAction(times = count) {
+            onCvcView().perform(pressKey(KeyEvent.KEYCODE_DPAD_LEFT))
+        }
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+    }
+
+    @Test
+    fun shouldMoveFocusToNextFieldWhenCaretIsAtTheEndUsingDirectionPad() {
+        val pan = "4111 111"
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasFocus(PAN)
+            .enterCardDetail(PAN, pan, false)
+            .setCursorPositionOnPan(0)
+
+        val count = pan.length + 1 // move cursor to end and one more to attempt to move focus
+
+        repeatAction(times = count) {
+            onCardPanView().perform(pressKey(KeyEvent.KEYCODE_DPAD_RIGHT))
+        }
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+    }
+
+    @Test
+    fun shouldMoveFocusToNextFieldWhenPressingTabKey() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasFocus(PAN)
+
+        onCardPanView().perform(pressKey(KeyEvent.KEYCODE_TAB))
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+
+        onExpiryDateView().perform(pressKey(KeyEvent.KEYCODE_TAB))
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+
+        onCvcView().perform(pressKey(KeyEvent.KEYCODE_TAB))
+
+        cardFragmentTestUtils
+            .hasFocus(PAN)
     }
 
     @Test

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
@@ -66,6 +66,62 @@ class CardFragmentTest : AbstractCardFragmentTest() {
     }
 
     @Test
+    fun shouldMoveFocusToNextFieldWithoutEnteringDetails() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasFocus(PAN)
+
+        onCardPanView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+
+        onExpiryDateView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+
+        onCvcView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils.keyboardIsClosed()
+    }
+
+    @Test
+    fun shouldMoveFocusToNextFieldWhenPartialDetailsAreEntered() {
+        // enter partial details in PAN field
+        cardFragmentTestUtils
+            .isInInitialState()
+            .hasFocus(PAN)
+            .enterCardDetail(PAN, "4111111", false)
+
+        // move to expiry date field via next action button
+        onCardPanView().perform(pressImeActionButton())
+
+        // verify focus is now on expiry date field and PAN field retains partial details
+        cardFragmentTestUtils
+            .validationStateIs(pan = false)
+            .hasFocus(EXPIRY_DATE)
+            .focusOn(PAN)
+
+        // move to expiry date field via next action button again
+        onCardPanView().perform(pressImeActionButton())
+
+        // verify focus is now on expiry date field
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+
+        // continue to CVC field without entering expiry date details
+        onExpiryDateView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+
+        onCvcView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils.keyboardIsClosed()
+    }
+
+    @Test
     fun shouldDisableSubmitButton_onInvalidCardData() {
         // invalid expiry month
         cardFragmentTestUtils

--- a/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
+++ b/demo-app/src/androidTestMock/java/com/worldpay/access/checkout/sample/card/standard/CardFragmentTest.kt
@@ -1,10 +1,14 @@
 package com.worldpay.access.checkout.sample.card.standard
 
+import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.worldpay.access.checkout.sample.R
 import com.worldpay.access.checkout.sample.card.standard.testutil.AbstractCardFragmentTest
 import com.worldpay.access.checkout.sample.card.standard.testutil.CardBrand.VISA
-import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.CVC
+import com.worldpay.access.checkout.sample.card.standard.testutil.CardFragmentTestUtils.Input.*
+import com.worldpay.access.checkout.sample.testutil.UITestUtils.onCardPanView
+import com.worldpay.access.checkout.sample.testutil.UITestUtils.onCvcView
+import com.worldpay.access.checkout.sample.testutil.UITestUtils.onExpiryDateView
 import com.worldpay.access.checkout.sample.testutil.UITestUtils.reopenApp
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,6 +40,29 @@ class CardFragmentTest : AbstractCardFragmentTest() {
             .hasAutofillHints(R.id.card_flow_text_pan, arrayOf("creditCardNumber"))
             .hasAutofillHints(R.id.card_flow_text_cvc, arrayOf("creditCardSecurityCode"))
             .hasAutofillHints(R.id.card_flow_expiry_date, arrayOf("creditCardExpirationDate"))
+    }
+
+    @Test
+    fun shouldMoveFocusToNextField() {
+        cardFragmentTestUtils
+            .isInInitialState()
+            .enterCardDetail(PAN, "4111111111111111", false)
+
+        onCardPanView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils
+            .hasFocus(EXPIRY_DATE)
+            .enterCardDetail(EXPIRY_DATE, "1140", false)
+
+        onExpiryDateView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils
+            .hasFocus(CVC)
+            .enterCardDetail(CVC, "123", false)
+
+        onCvcView().perform(pressImeActionButton())
+
+        cardFragmentTestUtils.keyboardIsClosed()
     }
 
     @Test

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -90,7 +90,7 @@
                     android:focusable="true"
                     android:focusableInTouchMode="true"
                     android:hint="@string/card_cvc_hint"
-                    android:imeOptions="actionDone"
+                    android:imeOptions="actionDone|flagNoFullscreen"
                     android:inputType="text"
                     android:nextFocusDown="@+id/card_flow_text_cvc"
                     android:nextFocusForward="@+id/card_flow_text_cvc"

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -1,139 +1,147 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/fragment_card_flow"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:focusable="auto"
-    tools:context=".sample.ui.CardFlowFragment">
+                                                   xmlns:tools="http://schemas.android.com/tools"
+                                                   android:id="@+id/fragment_card_flow"
+                                                   android:layout_width="match_parent"
+                                                   android:layout_height="match_parent"
+                                                   android:focusable="auto"
+                                                   tools:context=".sample.ui.CardFlowFragment">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:divider="@android:color/transparent"
-        android:dividerPadding="24dp"
-        android:orientation="vertical"
-        android:padding="24dp"
-        android:showDividers="middle">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:divider="@android:color/transparent"
+            android:dividerPadding="24dp"
+            android:orientation="vertical"
+            android:padding="24dp"
+            android:showDividers="middle"
+            tools:layout_editor_absoluteY="39dp"
+            tools:layout_editor_absoluteX="123dp">
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="24dp"
-            android:orientation="vertical">
-
-            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_marginBottom="24dp"
+                android:orientation="vertical">
+
+            <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                    android:id="@+id/card_flow_text_pan"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="4"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:focusableInTouchMode="true"
-                    android:hint="@string/card_number_hint"
-                    android:autofillHints="creditCardNumber"
-                    android:imeOptions="actionNext"
-                    >
-
-                </com.worldpay.access.checkout.ui.AccessCheckoutEditText>
+                        android:id="@+id/card_flow_text_pan"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="8dp"
+                        android:layout_weight="4"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:focusableInTouchMode="true"
+                        android:hint="@string/card_number_hint"
+                        android:autofillHints="creditCardNumber"
+                        android:imeOptions="actionNext"/>
 
                 <ImageView
-                    android:id="@+id/card_flow_brand_logo"
-                    android:layout_width="55dp"
-                    android:layout_height="45dp"
-                    android:layout_weight="1"
-                    android:contentDescription="@string/card_brand_icon"
-                    android:scaleType="centerInside"
-                    android:src="@drawable/card_unknown_logo" />
+                        android:id="@+id/card_flow_brand_logo"
+                        android:layout_width="55dp"
+                        android:layout_height="45dp"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/card_brand_icon"
+                        android:scaleType="centerInside"
+                        android:src="@drawable/card_unknown_logo"/>
 
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                    android:id="@+id/card_flow_expiry_date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="3"
-                    android:ems="4"
-                    android:hint="@string/card_expiry_date_hint"
-                    android:autofillHints="creditCardExpirationDate"
-                    android:imeOptions="actionNext"
-                    android:inputType="text"
-                    android:textColor="@color/DEFAULT"
-                    android:descendantFocusability="beforeDescendants"
-                    android:focusable="true"
-                    android:focusableInTouchMode="true"
-                    tools:ignore="TextFields" />
+                        android:id="@+id/card_flow_expiry_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="3"
+                        android:ems="4"
+                        android:hint="@string/card_expiry_date_hint"
+                        android:autofillHints="creditCardExpirationDate"
+                        android:imeOptions="actionNext"
+                        android:inputType="text"
+                        android:textColor="@color/DEFAULT"
+                        android:descendantFocusability="beforeDescendants"
+                        android:focusable="true"
+                        android:focusableInTouchMode="true"
+                        tools:ignore="TextFields"/>
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                    android:id="@+id/card_flow_text_cvc"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="2"
-                    android:ems="4"
-                    android:hint="@string/card_cvc_hint"
-                    android:autofillHints="creditCardSecurityCode"
-                    android:imeOptions="actionDone|flagNoFullscreen"
-                    android:inputType="text"
-                    android:textColor="@color/DEFAULT" />
+                        android:id="@+id/card_flow_text_cvc"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="2"
+                        android:ems="4"
+                        android:hint="@string/card_cvc_hint"
+                        android:autofillHints="creditCardSecurityCode"
+                        android:imeOptions="actionDone|flagNoFullscreen"
+                        android:inputType="text"
+                        android:textColor="@color/DEFAULT"
+                        android:descendantFocusability="beforeDescendants"
+                        android:focusable="true"
+                        android:focusableInTouchMode="true"
+                        android:clickable="true"/>
 
             </LinearLayout>
         </LinearLayout>
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:orientation="horizontal"
+                android:focusable="false"
+                android:focusableInTouchMode="false">
+
+            <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/card_flow_multi_session_switch_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/enable_multi_token_title"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                        android:id="@+id/card_flow_multi_session_switch_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:text="@string/enable_multi_token_title"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
 
                 <TextView
-                    android:id="@+id/card_flow_multi_session_switch_desc"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="@string/enable_multi_token_desc"
-                    android:textSize="12sp" />
+                        android:id="@+id/card_flow_multi_session_switch_desc"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:text="@string/enable_multi_token_desc"
+                        android:textSize="12sp"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"/>
             </LinearLayout>
 
             <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/card_flow_payments_cvc_switch"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_weight="4" />
+                    android:id="@+id/card_flow_payments_cvc_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_weight="4"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"/>
 
         </LinearLayout>
 
         <Button
-            android:id="@+id/card_flow_btn_submit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:background="@android:color/darker_gray"
-            android:enabled="false"
-            android:text="@string/submit_text"
-            android:textColor="@android:color/white" />
+                android:id="@+id/card_flow_btn_submit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:background="@android:color/darker_gray"
+                android:enabled="false"
+                android:text="@string/submit_text"
+                android:textColor="@android:color/white"/>
     </LinearLayout>
 
 

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -30,17 +30,19 @@
                     android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                        android:id="@+id/card_flow_text_pan"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="8dp"
-                        android:layout_weight="4"
-                        android:clickable="true"
-                        android:focusable="true"
-                        android:focusableInTouchMode="true"
-                        android:hint="@string/card_number_hint"
-                        android:autofillHints="creditCardNumber"
-                        android:imeOptions="actionNext"/>
+                    android:id="@+id/card_flow_text_pan"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_weight="4"
+                    android:autofillHints="creditCardNumber"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
+                    android:hint="@string/card_number_hint"
+                    android:imeOptions="actionNext"
+                    android:nextFocusDown="@+id/card_flow_expiry_date"
+                    android:nextFocusForward="@+id/card_flow_expiry_date" />
 
                 <ImageView
                         android:id="@+id/card_flow_brand_logo"
@@ -59,36 +61,40 @@
                     android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                        android:id="@+id/card_flow_expiry_date"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="3"
-                        android:ems="4"
-                        android:hint="@string/card_expiry_date_hint"
-                        android:autofillHints="creditCardExpirationDate"
-                        android:imeOptions="actionNext"
-                        android:inputType="text"
-                        android:textColor="@color/DEFAULT"
-                        android:descendantFocusability="beforeDescendants"
-                        android:focusable="true"
-                        android:focusableInTouchMode="true"
-                        tools:ignore="TextFields"/>
+                    android:id="@+id/card_flow_expiry_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="3"
+                    android:autofillHints="creditCardExpirationDate"
+                    android:descendantFocusability="beforeDescendants"
+                    android:ems="4"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
+                    android:hint="@string/card_expiry_date_hint"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:nextFocusDown="@+id/card_flow_text_cvc"
+                    android:nextFocusForward="@+id/card_flow_text_cvc"
+                    android:textColor="@color/DEFAULT"
+                    tools:ignore="TextFields" />
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
-                        android:id="@+id/card_flow_text_cvc"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="2"
-                        android:ems="4"
-                        android:hint="@string/card_cvc_hint"
-                        android:autofillHints="creditCardSecurityCode"
-                        android:imeOptions="actionDone|flagNoFullscreen"
-                        android:inputType="text"
-                        android:textColor="@color/DEFAULT"
-                        android:descendantFocusability="beforeDescendants"
-                        android:focusable="true"
-                        android:focusableInTouchMode="true"
-                        android:clickable="true"/>
+                    android:id="@+id/card_flow_text_cvc"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:autofillHints="creditCardSecurityCode"
+                    android:clickable="true"
+                    android:descendantFocusability="beforeDescendants"
+                    android:ems="4"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
+                    android:hint="@string/card_cvc_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:nextFocusDown="@+id/card_flow_text_cvc"
+                    android:nextFocusForward="@+id/card_flow_text_cvc"
+                    android:textColor="@color/DEFAULT" />
 
             </LinearLayout>
         </LinearLayout>

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:tools="http://schemas.android.com/tools"
-                                                   android:id="@+id/fragment_card_flow"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="match_parent"
-                                                   android:focusable="auto"
-                                                   tools:context=".sample.ui.CardFlowFragment">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_card_flow"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:focusable="auto"
+    tools:context=".sample.ui.CardFlowFragment">
 
     <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:divider="@android:color/transparent"
-            android:dividerPadding="24dp"
-            android:orientation="vertical"
-            android:padding="24dp"
-            android:showDividers="middle"
-            tools:layout_editor_absoluteY="39dp"
-            tools:layout_editor_absoluteX="123dp">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:divider="@android:color/transparent"
+        android:dividerPadding="24dp"
+        android:orientation="vertical"
+        android:padding="24dp"
+        android:showDividers="middle"
+        tools:layout_editor_absoluteX="123dp"
+        tools:layout_editor_absoluteY="39dp">
 
         <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
-                android:orientation="vertical">
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
 
             <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
                     android:id="@+id/card_flow_text_pan"
@@ -41,24 +41,24 @@
                     android:focusableInTouchMode="true"
                     android:hint="@string/card_number_hint"
                     android:imeOptions="actionNext"
-                    android:nextFocusDown="@+id/card_flow_expiry_date"
+                    android:nextFocusRight="@+id/card_flow_expiry_date"
                     android:nextFocusForward="@+id/card_flow_expiry_date" />
 
                 <ImageView
-                        android:id="@+id/card_flow_brand_logo"
-                        android:layout_width="55dp"
-                        android:layout_height="45dp"
-                        android:layout_weight="1"
-                        android:contentDescription="@string/card_brand_icon"
-                        android:scaleType="centerInside"
-                        android:src="@drawable/card_unknown_logo"/>
+                    android:id="@+id/card_flow_brand_logo"
+                    android:layout_width="55dp"
+                    android:layout_height="45dp"
+                    android:layout_weight="1"
+                    android:contentDescription="@string/card_brand_icon"
+                    android:scaleType="centerInside"
+                    android:src="@drawable/card_unknown_logo" />
 
             </LinearLayout>
 
             <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
                 <com.worldpay.access.checkout.ui.AccessCheckoutEditText
                     android:id="@+id/card_flow_expiry_date"
@@ -73,6 +73,7 @@
                     android:hint="@string/card_expiry_date_hint"
                     android:imeOptions="actionNext"
                     android:inputType="text"
+                    android:nextFocusRight="@+id/card_flow_text_cvc"
                     android:nextFocusDown="@+id/card_flow_text_cvc"
                     android:nextFocusForward="@+id/card_flow_text_cvc"
                     android:textColor="@color/DEFAULT"
@@ -92,62 +93,62 @@
                     android:hint="@string/card_cvc_hint"
                     android:imeOptions="actionDone|flagNoFullscreen"
                     android:inputType="text"
+                    android:nextFocusLeft="@+id/card_flow_expiry_date"
+                    android:nextFocusUp="@+id/card_flow_text_pan"
                     android:nextFocusDown="@+id/card_flow_text_cvc"
-                    android:nextFocusForward="@+id/card_flow_text_cvc"
+                    android:nextFocusForward="@+id/card_flow_text_pan"
                     android:textColor="@color/DEFAULT" />
 
             </LinearLayout>
         </LinearLayout>
 
         <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="false"
-                android:focusableInTouchMode="false">
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:orientation="horizontal">
 
             <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/card_flow_multi_session_switch_title"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:layout_height="match_parent"
+                    android:text="@string/enable_multi_token_title"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                 <TextView
-                        android:id="@+id/card_flow_multi_session_switch_title"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:text="@string/enable_multi_token_title"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
-
-                <TextView
-                        android:id="@+id/card_flow_multi_session_switch_desc"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:text="@string/enable_multi_token_desc"
-                        android:textSize="12sp"
-                        android:focusable="false"
-                        android:focusableInTouchMode="false"/>
+                    android:id="@+id/card_flow_multi_session_switch_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:text="@string/enable_multi_token_desc"
+                    android:textSize="12sp" />
             </LinearLayout>
 
             <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/card_flow_payments_cvc_switch"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_weight="4"
-                    android:focusable="false"
-                    android:focusableInTouchMode="false"/>
+                android:id="@+id/card_flow_payments_cvc_switch"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="4"
+                android:focusable="false"
+                android:focusableInTouchMode="false" />
 
         </LinearLayout>
 
         <Button
-                android:id="@+id/card_flow_btn_submit"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:background="@android:color/darker_gray"
-                android:enabled="false"
-                android:text="@string/submit_text"
-                android:textColor="@android:color/white"/>
+            android:id="@+id/card_flow_btn_submit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:background="@android:color/darker_gray"
+            android:enabled="false"
+            android:text="@string/submit_text"
+            android:textColor="@android:color/white" />
     </LinearLayout>
 
 

--- a/demo-app/src/main/res/layout/fragment_card_flow.xml
+++ b/demo-app/src/main/res/layout/fragment_card_flow.xml
@@ -38,7 +38,9 @@
                     android:focusable="true"
                     android:focusableInTouchMode="true"
                     android:hint="@string/card_number_hint"
-                    android:autofillHints="creditCardNumber">
+                    android:autofillHints="creditCardNumber"
+                    android:imeOptions="actionNext"
+                    >
 
                 </com.worldpay.access.checkout.ui.AccessCheckoutEditText>
 
@@ -66,7 +68,7 @@
                     android:ems="4"
                     android:hint="@string/card_expiry_date_hint"
                     android:autofillHints="creditCardExpirationDate"
-                    android:imeOptions="actionDone|flagNoFullscreen"
+                    android:imeOptions="actionNext"
                     android:inputType="text"
                     android:textColor="@color/DEFAULT"
                     android:descendantFocusability="beforeDescendants"


### PR DESCRIPTION
Fixes https://github.com/Worldpay/access-checkout-android/issues/264

## What
- Fix AccessCheckoutEditText bug where focus does not change correctly
- Added support for keyboard navigation

## How
- Implement Focus fix suggested in https://github.com/Worldpay/access-checkout-android/pull/271 and https://github.com/Worldpay/access-checkout-android/issues/264
- Add test to cover moving focus to next `AccessCheckoutEditText`
- Update imeOptions in demo app

## Why
- so that the focus behaviour moving from one `AccessCheckoutEditText` to another `AccessCheckoutEditText` functions correctly.